### PR TITLE
Add static handling to mailchimp_get_api_object().

### DIFF
--- a/mailchimp.module
+++ b/mailchimp.module
@@ -1177,11 +1177,9 @@ function mailchimp_cron() {
   if ($queue_count > 0) {
     $batch_limit = variable_get('mailchimp_batch_limit', 100);
     $batch_size = ($queue_count < $batch_limit) ? $queue_count : $batch_limit;
-    $mcapi = mailchimp_get_api_object();
     $count = 0;
     while ($count < $batch_size) {
       if ($item = $queue->claimItem()) {
-        $item->data['args'][] = $mcapi;
         // Flag the function so it doesn't go back in the queue:
         $item->data['args'][] = FALSE;
         call_user_func_array($item->data['function'], $item->data['args']);

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -761,7 +761,7 @@ function mailchimp_get_campaign_data($campaign_id, $reset = FALSE) {
       }
     }
     catch (Exception $e) {
-      watchdog('mailchimp', 'An error occurred retreiving campaign data for @campaign. "%message"', array(
+      watchdog('mailchimp', 'An error occurred retrieving campaign data for @campaign. "%message"', array(
         '@campaign' => $campaign_id,
         '%message' => $e->getMessage(),
       ), WATCHDOG_ERROR);

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -89,6 +89,11 @@ function mailchimp_permission() {
  *   can be overridden.
  */
 function mailchimp_get_api_object() {
+  $mailchimp = &drupal_static(__FUNCTION__);
+  if (isset($mailchimp)) {
+    return $mailchimp;
+  }
+
   $library = libraries_load('mailchimp');
   if (!$library['installed']) {
     $msg = t('Failed to load MailChimp PHP library. Please refer to the installation requirements.');

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -336,60 +336,62 @@ function mailchimp_is_subscribed($list_id, $email, $reset = FALSE) {
 /**
  * Wrapper around MCAPI->lists->subscribe.
  */
-function mailchimp_subscribe($list_id, $email, $merge_vars = NULL, $double_optin = FALSE, $format = 'html', $update_existing = TRUE, $replace_interests = TRUE, $confirm = TRUE, $mcapi = NULL, $allow_async = TRUE) {
+function mailchimp_subscribe($list_id, $email, $merge_vars = NULL, $double_optin = FALSE, $format = 'html', $update_existing = TRUE, $replace_interests = TRUE, $confirm = TRUE, $allow_async = TRUE) {
   $success = FALSE;
-  // If we aren't given an MCAPI object, we allow Async in our API object.
-  // The object itself will tell us whether to use the queue.
-  if ($mcapi || $mcapi = mailchimp_get_api_object()) {
-    if ($allow_async && variable_get('mailchimp_cron', FALSE)) {
-      $queue = DrupalQueue::get(MAILCHIMP_QUEUE_CRON);
-      $queue->createQueue();
-      $success = $queue->createItem(array(
-        'function' => 'mailchimp_subscribe',
-        'args' => array(
-          'list_id' => $list_id,
-          'email' => $email,
-          'merge_vars' => $merge_vars,
-          'format' => $format,
-          'double_optin' => $double_optin,
-          'update_existing' => $update_existing,
-          'replace_interests' => $replace_interests,
-          'confirm' => $confirm,
-        ),
-      ));
-      if (!$success) {
-        watchdog('mailchimp', 'A problem occurred adding a mailchimp subscription to the queue. Email: @email List: @list.', array(
+  $mcapi = mailchimp_get_api_object();
+  if (!$mcapi) {
+    return FALSE;
+  }
+
+  // Process asynchronously if not being called from CRON.
+  if ($allow_async && variable_get('mailchimp_cron', FALSE)) {
+    $queue = DrupalQueue::get(MAILCHIMP_QUEUE_CRON);
+    $queue->createQueue();
+    $success = $queue->createItem(array(
+      'function' => 'mailchimp_subscribe',
+      'args' => array(
+        'list_id' => $list_id,
+        'email' => $email,
+        'merge_vars' => $merge_vars,
+        'format' => $format,
+        'double_optin' => $double_optin,
+        'update_existing' => $update_existing,
+        'replace_interests' => $replace_interests,
+        'confirm' => $confirm,
+      ),
+    ));
+    if (!$success) {
+      watchdog('mailchimp', 'A problem occurred adding a mailchimp subscription to the queue. Email: @email List: @list.', array(
+        '@email' => $email,
+        '@list' => $list_id,
+      ), WATCHDOG_WARNING);
+    }
+  }
+  else {
+    try {
+      $result = $mcapi->lists->subscribe($list_id, array('email' => $email), $merge_vars, $format, $double_optin, $update_existing, $replace_interests, $confirm);
+      if (isset($result['email'])) {
+        $success = $result;
+        module_invoke_all('mailchimp_subscribe_user', $list_id, $email, $merge_vars);
+        // Clear user cache, just in case there's some cruft leftover:
+        mailchimp_cache_clear_member($list_id, $email);
+        watchdog('mailchimp', '@email was subscribed to list @list.',
+          array('@email' => $merge_vars['EMAIL'], '@list' => $list_id), WATCHDOG_NOTICE
+        );
+      }
+      else {
+        watchdog('mailchimp', 'A problem occurred subscribing @email to list @list.', array(
           '@email' => $email,
           '@list' => $list_id,
         ), WATCHDOG_WARNING);
       }
     }
-    else {
-      try {
-        $result = $mcapi->lists->subscribe($list_id, array('email' => $email), $merge_vars, $format, $double_optin, $update_existing, $replace_interests, $confirm);
-        if (isset($result['email'])) {
-          $success = $result;
-          module_invoke_all('mailchimp_subscribe_user', $list_id, $email, $merge_vars);
-          // Clear user cache, just in case there's some cruft leftover:
-          mailchimp_cache_clear_member($list_id, $email);
-          watchdog('mailchimp', '@email was subscribed to list @list.',
-            array('@email' => $merge_vars['EMAIL'], '@list' => $list_id), WATCHDOG_NOTICE
-          );
-        }
-        else {
-          watchdog('mailchimp', 'A problem occurred subscribing @email to list @list.', array(
-            '@email' => $email,
-            '@list' => $list_id,
-          ), WATCHDOG_WARNING);
-        }
-      }
-      catch (Exception $e) {
-        watchdog('mailchimp', 'An error occurred subscribing @email to list @list. "%message"', array(
-          '@email' => $email,
-          '@list' => $list_id,
-          '%message' => $e->getMessage(),
-        ), WATCHDOG_ERROR);
-      }
+    catch (Exception $e) {
+      watchdog('mailchimp', 'An error occurred subscribing @email to list @list. "%message"', array(
+        '@email' => $email,
+        '@list' => $list_id,
+        '%message' => $e->getMessage(),
+      ), WATCHDOG_ERROR);
     }
   }
 
@@ -399,57 +401,58 @@ function mailchimp_subscribe($list_id, $email, $merge_vars = NULL, $double_optin
 /**
  * Wrapper around MCAPI->lists->updateMember.
  */
-function mailchimp_update_member($list_id, $email, $merge_vars, $format = '', $replace_interests = TRUE, $mcapi = NULL, $allow_async = TRUE) {
+function mailchimp_update_member($list_id, $email, $merge_vars, $format = '', $replace_interests = TRUE, $allow_async = TRUE) {
   $success = FALSE;
-  // If we aren't given an MCAPI object, we allow Async in our API object.
-  // The object itself will tell us whether to use the queue.
-  if ($mcapi || $mcapi = mailchimp_get_api_object()) {
-    if ($allow_async && variable_get('mailchimp_cron', FALSE)) {
-      $queue = DrupalQueue::get(MAILCHIMP_QUEUE_CRON);
-      $queue->createQueue();
-      $success = $queue->createItem(array(
-        'function' => 'mailchimp_update_member',
-        'args' => array(
-          'list_id' => $list_id,
-          'email' => $email,
-          'merge_vars' => $merge_vars,
-          'format' => $format,
-          'replace_interests' => $replace_interests,
-        ),
-      ));
-      if (!$success) {
-        watchdog('mailchimp', 'A problem occurred adding a mailchimp membership update to the queue. Email: @email List: @list.', array(
+  $mcapi = $mcapi = mailchimp_get_api_object();
+  if (!$mcapi) {
+    return FALSE;
+  }
+
+  if ($allow_async && variable_get('mailchimp_cron', FALSE)) {
+    $queue = DrupalQueue::get(MAILCHIMP_QUEUE_CRON);
+    $queue->createQueue();
+    $success = $queue->createItem(array(
+      'function' => 'mailchimp_update_member',
+      'args' => array(
+        'list_id' => $list_id,
+        'email' => $email,
+        'merge_vars' => $merge_vars,
+        'format' => $format,
+        'replace_interests' => $replace_interests,
+      ),
+    ));
+    if (!$success) {
+      watchdog('mailchimp', 'A problem occurred adding a mailchimp membership update to the queue. Email: @email List: @list.', array(
+        '@email' => $email,
+        '@list' => $list_id,
+      ), WATCHDOG_WARNING);
+    }
+  }
+  else {
+    try {
+      $result = $mcapi->lists->updateMember($list_id, array('email' => $email), $merge_vars, $format, $replace_interests);
+      if (isset($result['email'])) {
+        $success = $result;
+        watchdog('mailchimp', '@email was updated in list @list_id.', array(
+          '@email' => $email,
+          '@list' => $list_id,
+        ), WATCHDOG_NOTICE);
+        // Clear user cache:
+        mailchimp_cache_clear_member($list_id, $email);
+      }
+      else {
+        watchdog('mailchimp', 'A problem occurred updating @email on list @list.', array(
           '@email' => $email,
           '@list' => $list_id,
         ), WATCHDOG_WARNING);
       }
     }
-    else {
-      try {
-        $result = $mcapi->lists->updateMember($list_id, array('email' => $email), $merge_vars, $format, $replace_interests);
-        if (isset($result['email'])) {
-          $success = $result;
-          watchdog('mailchimp', '@email was updated in list @list_id.', array(
-            '@email' => $email,
-            '@list' => $list_id,
-          ), WATCHDOG_NOTICE);
-          // Clear user cache:
-          mailchimp_cache_clear_member($list_id, $email);
-        }
-        else {
-          watchdog('mailchimp', 'A problem occurred updating @email on list @list.', array(
-            '@email' => $email,
-            '@list' => $list_id,
-          ), WATCHDOG_WARNING);
-        }
-      }
-      catch (Exception $e) {
-        watchdog('mailchimp', 'An error occurred updating @email on list @list. "%message"', array(
-          '@email' => $email,
-          '@list' => $list_id,
-          '%message' => $e->getMessage(),
-        ), WATCHDOG_ERROR);
-      }
+    catch (Exception $e) {
+      watchdog('mailchimp', 'An error occurred updating @email on list @list. "%message"', array(
+        '@email' => $email,
+        '@list' => $list_id,
+        '%message' => $e->getMessage(),
+      ), WATCHDOG_ERROR);
     }
   }
 
@@ -525,48 +528,49 @@ function mailchimp_batch_update_members($list_id, $batch, $double_in = FALSE, $u
  * @return bool
  *   Indicates whether unsubscribe was successful.
  */
-function mailchimp_unsubscribe($list_id, $email, $delete = FALSE, $goodbye = FALSE, $notify = FALSE, $mcapi = NULL, $allow_async = TRUE) {
+function mailchimp_unsubscribe($list_id, $email, $delete = FALSE, $goodbye = FALSE, $notify = FALSE, $allow_async = TRUE) {
   $success = FALSE;
-  // If we aren't given an MCAPI object, we allow Async in our API object.
-  // The object itself will tell us whether to use the queue.
-  if ($mcapi || $mcapi = mailchimp_get_api_object()) {
-    if (mailchimp_is_subscribed($list_id, $email)) {
-      if ($allow_async && variable_get('mailchimp_cron', FALSE)) {
-        $queue = DrupalQueue::get(MAILCHIMP_QUEUE_CRON);
-        $queue->createQueue();
-        $success = $queue->createItem(array(
-          'function' => 'mailchimp_unsubscribe',
-          'args' => array(
-            'list_id' => $list_id,
-            'email' => $email,
-            'delete' => $delete,
-            'goodbye' => $goodbye,
-            'notify' => $notify,
-          ),
-        ));
-        if (!$success) {
-          watchdog('mailchimp', 'A problem occurred adding a mailchimp unsubscribe to the queue. Email: @email List: @list.', array(
-            '@email' => $email,
-            '@list' => $list_id,
-          ), WATCHDOG_WARNING);
-        }
+  $mcapi = mailchimp_get_api_object();
+  if (!$mcapi) {
+    return FALSE;
+  }
+
+  if (mailchimp_is_subscribed($list_id, $email)) {
+    if ($allow_async && variable_get('mailchimp_cron', FALSE)) {
+      $queue = DrupalQueue::get(MAILCHIMP_QUEUE_CRON);
+      $queue->createQueue();
+      $success = $queue->createItem(array(
+        'function' => 'mailchimp_unsubscribe',
+        'args' => array(
+          'list_id' => $list_id,
+          'email' => $email,
+          'delete' => $delete,
+          'goodbye' => $goodbye,
+          'notify' => $notify,
+        ),
+      ));
+      if (!$success) {
+        watchdog('mailchimp', 'A problem occurred adding a mailchimp unsubscribe to the queue. Email: @email List: @list.', array(
+          '@email' => $email,
+          '@list' => $list_id,
+        ), WATCHDOG_WARNING);
       }
-      else {
-        try {
-          $success = $mcapi->lists->unsubscribe($list_id, array('email' => $email), $delete, $goodbye, $notify);
-          if ($success) {
-            module_invoke_all('mailchimp_unsubscribe_user', $list_id, $email);
-          }
-          // Clear user cache:
-          mailchimp_cache_clear_member($list_id, $email);
+    }
+    else {
+      try {
+        $success = $mcapi->lists->unsubscribe($list_id, array('email' => $email), $delete, $goodbye, $notify);
+        if ($success) {
+          module_invoke_all('mailchimp_unsubscribe_user', $list_id, $email);
         }
-        catch (Exception $e) {
-          watchdog('mailchimp', 'An error occurred unsubscribing @email from list @list. "%message"', array(
-            '@email' => $email,
-            '@list' => $list_id,
-            '%message' => $e->getMessage(),
-          ), WATCHDOG_ERROR);
-        }
+        // Clear user cache:
+        mailchimp_cache_clear_member($list_id, $email);
+      }
+      catch (Exception $e) {
+        watchdog('mailchimp', 'An error occurred unsubscribing @email from list @list. "%message"', array(
+          '@email' => $email,
+          '@list' => $list_id,
+          '%message' => $e->getMessage(),
+        ), WATCHDOG_ERROR);
       }
     }
   }


### PR DESCRIPTION
Removes the need for passing the mcapi object in cron and as a null parameter to subscribe functions.
