### PR TITLE
Added mailchimp_test_mode variable to allow alternate logic during tests.

### DIFF
--- a/mailchimp.module
+++ b/mailchimp.module
@@ -385,10 +385,12 @@ function mailchimp_subscribe($list_id, $email, $merge_vars = NULL, $double_optin
         );
       }
       else {
-        watchdog('mailchimp', 'A problem occurred subscribing @email to list @list.', array(
-          '@email' => $email,
-          '@list' => $list_id,
-        ), WATCHDOG_WARNING);
+        if (!variable_get('mailchimp_test_mode')) {
+          watchdog('mailchimp', 'A problem occurred subscribing @email to list @list.', array(
+            '@email' => $email,
+            '@list' => $list_id,
+          ), WATCHDOG_WARNING);
+        }
       }
     }
     catch (Exception $e) {

--- a/modules/mailchimp_campaign/tests/mailchimp_campaigns.test
+++ b/modules/mailchimp_campaign/tests/mailchimp_campaigns.test
@@ -28,7 +28,7 @@ class MailchimpCampaignsTestCase extends DrupalWebTestCase {
    * Sets the mailchimp_api_key to the test-mode key.
    * Sets test mode to TRUE.
    */
-  public function setUp() {
+  protected function setUp() {
     // Use a profile that contains required modules:
     $prof = drupal_get_profile();
     $this->profile = $prof;

--- a/modules/mailchimp_campaign/tests/mailchimp_campaigns.test
+++ b/modules/mailchimp_campaign/tests/mailchimp_campaigns.test
@@ -26,6 +26,7 @@ class MailchimpCampaignsTestCase extends DrupalWebTestCase {
    *
    * Enables dependencies.
    * Sets the mailchimp_api_key to the test-mode key.
+   * Sets test mode to TRUE.
    */
   public function setUp() {
     // Use a profile that contains required modules:
@@ -42,6 +43,17 @@ class MailchimpCampaignsTestCase extends DrupalWebTestCase {
     parent::setUp($enabled_modules);
     variable_set('mailchimp_api_classname', 'MailChimpTest');
     variable_set('mailchimp_api_key', 'MAILCHIMP_TEST_API_KEY');
+    variable_set('mailchimp_test_mode', TRUE);
+  }
+
+  /**
+   * Post-test function.
+   *
+   * Sets test mode to FALSE.
+   */
+  protected function tearDown() {
+    parent::tearDown();
+    variable_set('mailchimp_test_mode', FALSE);
   }
 
   /**

--- a/modules/mailchimp_lists/tests/mailchimp_lists.test
+++ b/modules/mailchimp_lists/tests/mailchimp_lists.test
@@ -26,8 +26,9 @@ class MailchimpListsTestCase extends DrupalWebTestCase {
    *
    * Enables dependencies.
    * Sets the mailchimp_api_key to the test-mode key.
+   * Sets test mode to TRUE.
    */
-  public function setUp() {
+  protected function setUp() {
     // Use a profile that contains required modules:
     $prof = drupal_get_profile();
     $this->profile = $prof;
@@ -42,6 +43,17 @@ class MailchimpListsTestCase extends DrupalWebTestCase {
     parent::setUp($enabled_modules);
     variable_set('mailchimp_api_classname', 'MailChimpTest');
     variable_set('mailchimp_api_key', 'MAILCHIMP_TEST_API_KEY');
+    variable_set('mailchimp_test_mode', TRUE);
+  }
+
+  /**
+   * Post-test function.
+   *
+   * Sets test mode to FALSE.
+   */
+  protected function tearDown() {
+    parent::tearDown();
+    variable_set('mailchimp_test_mode', FALSE);
   }
 
   /**


### PR DESCRIPTION
@levelos This fixes #52 

Couldn't wrap the whole thing in a try / catch block, as the exception is already caught in mailchimp_subscribe. This solution has potential use outside of this case in the future.
