### PR TITLE
Content Import Refactor

### DIFF
--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -131,21 +131,6 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
     $merge_vars = array();
   }
 
-  $entity_info = _mailchimp_campaign_get_entities_for_content_import();
-  $entity_options = _mailchimp_campaign_build_entity_option_list($entity_info);
-
-  if (!empty($form_state['values']['content']['entity_import']['entity_type'])) {
-    $entity_type = $form_state['values']['content']['entity_import']['entity_type'];
-  }
-  else {
-    reset($entity_options);
-    $entity_type = current(array_keys($entity_options));
-  }
-
-  $entity_view_mode_options = _mailchimp_campaign_build_entity_view_mode_option_list($entity_info[$entity_type]);
-
-
-
   if ($mc_template) {
     if (strpos($mc_template['info']['source'], 'mc:repeatable')) {
       drupal_set_message(t('WARNING: This template has repeating sections, which are not supported. You may want to select a different template.'), 'warning');
@@ -172,59 +157,10 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
         '#default_value' => $default_value,
       );
 
-      if (isset($merge_vars)) {
-        $form['content'][$section . '_wrapper']['merge_vars'] = array (
-          '#type' => 'item',
-          '#title' => 'Merge Vars',
-          '#markup' => _mailchimp_campaign_build_merge_vars_html($merge_vars),
-        );
-      }
-
-      $form['content'][$section . '_wrapper']['entity_import'] = array(
-        '#id' => 'entity-import',
+      $form['content'][$section . '_wrapper']['merge_vars'] = array(
         '#type' => 'item',
-        '#title' => t('Site content import'),
-        '#collapsible' => FALSE,
-      );
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_type'] = array(
-        '#type' => 'select',
-        '#title' => t('Entity Type'),
-        '#options' => $entity_options,
-        '#default_value' => $entity_type,
-        '#ajax' => array(
-          'callback' => 'mailchimp_campaign_entity_type_callback',
-          'method' => 'replace',
-          'wrapper' => 'content-entity-lookup-wrapper',
-        ),
-      );
-      $form['content'][$section . '_wrapper']['entity_import']['entity_type']['#attributes']['class'][] = 'entity-import-entity-type';
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_id'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Entity Title'),
-        // Pass entity type as first parameter to entity autocomplete callback.
-        '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
-        '#prefix' => '<div id="content-entity-lookup-wrapper">',
-      );
-      $form['content'][$section . '_wrapper']['entity_import']['entity_id']['#attributes']['class'][] = 'entity-import-entity-id';
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_view_mode'] = array(
-        '#type' => 'select',
-        '#title' => t('View Mode'),
-        '#options' => $entity_view_mode_options,
-        '#suffix' => '</div>',
-      );
-      $form['content'][$section . '_wrapper']['entity_import']['entity_view_mode']['#attributes']['class'][] = 'entity-import-entity-view-mode';
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_import_link'] = array(
-        '#type' => 'item',
-        '#markup' => '<a id="add-entity-token" href="javascript:void(0);">Add entity token</a>',
-      );
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_import_tag'] = array(
-        '#type' => 'item',
-        '#markup' => '<div id="entity-import-tag-field"></div>',
+        '#title' => 'Merge Vars',
+        '#markup' => _mailchimp_campaign_build_merge_vars_html($merge_vars),
       );
     }
   }
@@ -364,67 +300,6 @@ function mailchimp_campaign_campaign_form_submit($form, &$form_state) {
   cache_clear_all('mailchimp_campaign_campaigns', 'cache');
 
   $form_state['redirect'][] = 'admin/config/services/mailchimp/campaigns';
-}
-
-/**
- * Returns an array of entities based on data from entity_get_info().
- *
- * Filters out entities that do not contain a title field, as they cannot
- * be used to import content into templates.
- *
- * @return array
- *   Filtered entities from entity_get_info().
- */
-function _mailchimp_campaign_get_entities_for_content_import() {
-  $entity_info = entity_get_info();
-
-  $filtered_entities = array();
-  foreach ($entity_info as $key => $entity) {
-    if (in_array('title', $entity['schema_fields_sql']['base table'])) {
-      $filtered_entities[$key] = $entity;
-    }
-  }
-
-  return $filtered_entities;
-}
-
-/**
- * Returns an options list of entities based on data from entity_get_info().
- *
- * Filters out entities that do not contain a title field, as they cannot
- * be used to import content into templates.
- *
- * @param array $entity_info
- *   Array of entities as returned by entity_get_info().
- *
- * @return array
- *   Associative array of entity IDs to name.
- */
-function _mailchimp_campaign_build_entity_option_list($entity_info) {
-  $options = array();
-  foreach ($entity_info as $entity_id => $entity_data) {
-    $options[$entity_id] = $entity_data['label'];
-  }
-
-  return $options;
-}
-
-/**
- * Returns an options list of entity view modes.
- *
- * @param array $entity
- *   Array of entity data as returned by entity_get_info().
- *
- * @return array
- *   Associative array of view mode IDs to name.
- */
-function _mailchimp_campaign_build_entity_view_mode_option_list(array $entity) {
-  $options = array();
-  foreach ($entity['view modes'] as $view_mode_id => $view_mode_data) {
-    $options[$view_mode_id] = $view_mode_data['label'];
-  }
-
-  return $options;
 }
 
 /**

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -157,8 +157,8 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
         '#default_value' => $default_value,
       );
 
-      $entity_type = isset($form_state['values']['content'][ $section . '_wrapper']['entity_import']['entity_type']) ?
-        $form_state['values']['content'][ $section . '_wrapper']['entity_import']['entity_type'] : NULL;
+      $entity_type = isset($form_state['values']['content'][$section . '_wrapper']['entity_import']['entity_type']) ?
+        $form_state['values']['content'][$section . '_wrapper']['entity_import']['entity_type'] : NULL;
 
       // Get available entity types.
       $entity_info = _mailchimp_campaign_get_entities_for_content_import();

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -319,13 +319,14 @@ function mailchimp_campaign_get_entity_import_form_elements($entity_type, $secti
     '#id' => 'entity-import',
     '#type' => 'fieldset',
     '#title' => t('Insert site content'),
-    '#description' => t('You can insert an entity of a given type and pick the view mode that will be rendered within this campaign section.'),
-    '#collapsible' => FALSE,
-    '#states' => array(
-      'visible' => array(
-        ':input[name="content[' . $section . '_wrapper][' . $section . '][format]"]' => array('value' => 'mailchimp_campaign'),
-      ),
-    ),
+    '#description' => t('<b>For use only with text filters that use the MailChimp Campaign filter</b><br />You can insert an entity of a given type and pick the view mode that will be rendered within this campaign section.'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    // '#states' => array(
+    //   'visible' => array(
+    //     ':input[name="content[' . $section . '_wrapper][' . $section . '][format]"]' => array('value' => 'mailchimp_campaign'),
+    //   ),
+    // ),
   );
 
   $form['entity_import']['entity_type'] = array(

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -26,11 +26,12 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
     '#required' => TRUE,
     '#default_value' => ($campaign) ? $campaign->mc_data['subject'] : '',
   );
+  $mailchimp_lists = mailchimp_get_lists();
   $form['list_id'] = array(
     '#type' => 'select',
     '#title' => t('List'),
     '#description' => t('Select the list this campaign should be sent to.'),
-    '#options' => _mailchimp_campaign_build_option_list(mailchimp_get_lists()),
+    '#options' => _mailchimp_campaign_build_option_list($mailchimp_lists),
     '#default_value' => ($campaign) ? $campaign->mc_data['list_id'] : -1,
     '#required' => TRUE,
     '#ajax' => array(
@@ -241,8 +242,17 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
 
       $form['content'][$section . '_wrapper']['merge_vars'] = array(
         '#type' => 'item',
-        '#title' => 'Merge Vars',
+        '#title' => 'MailChimp merge variables',
         '#markup' => _mailchimp_campaign_build_merge_vars_html($merge_vars),
+        '#description' => t(
+          'Insert merge variables from the the %list_name list or one of the !standard_link.',
+          array(
+            '%list_name' => $mailchimp_lists[$list_id]['name'],
+            '!standard_link' => l(
+              t('standard MailChimp merge variables'), 'http://kb.mailchimp.com/article/all-the-merge-tags-cheatsheet',
+              array('attributes' => array('target' => '_blank'))),
+          )
+        ),
       );
     }
   }

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -167,7 +167,8 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
       $form['content'][$section . '_wrapper']['entity_import'] = array(
         '#id' => 'entity-import',
         '#type' => 'fieldset',
-        '#title' => t('Site Content Import'),
+        '#title' => t('Insert site content'),
+        '#description' => t('You can insert an entity of a given type and pick the view mode that will be rendered within this campaign section.'),
         '#collapsible' => FALSE,
         '#states' => array(
           'visible' => array(

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -220,7 +220,7 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
 
       $form['content'][$section . '_wrapper']['entity_import']['entity_import_link'] = array(
         '#type' => 'item',
-        '#markup' => '<a id="' . $section . '-add-entity-token-link" class="add-entity-token-link" href="javascript:void(0);">Add entity token test</a>',
+        '#markup' => '<a id="' . $section . '-add-entity-token-link" class="add-entity-token-link" href="javascript:void(0);">' . t('Insert entity token') . '</a>',
         '#states' => array(
           'invisible' => array(
             ':input[name="content[' . $section . '_wrapper][entity_import][entity_type]"]' => array('value' => ''),

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -229,17 +229,6 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
         ),
       );
 
-      $form['content'][$section . '_wrapper']['entity_import']['entity_import_tag'] = array(
-        '#type' => 'item',
-        '#markup' => '<div id="' . $section . '-entity-import-tag-field" class="' . $section . '-entity-import-tag-field"></div>',
-        '#states' => array(
-          'invisible' => array(
-            ':input[name="content[' . $section . '_wrapper][entity_import][entity_type]"]' => array('value' => ''),
-          ),
-        ),
-      );
-      $form['content'][$section . '_wrapper']['entity_import']['entity_import_tag']['#attributes']['class'][] = 'entity-import-entity-import-tag';
-
       $form['content'][$section . '_wrapper']['merge_vars'] = array(
         '#type' => 'item',
         '#title' => 'MailChimp merge variables',

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -495,14 +495,15 @@ function _mailchimp_campaign_build_entity_view_mode_option_list(array $entity) {
  */
 function _mailchimp_campaign_build_merge_vars_html($merge_vars) {
   if (!empty($merge_vars)) {
+    $rows = array();
     foreach ($merge_vars as $var) {
       $rows[] = array(
         $var['name'],
         '<a id="merge-var-' . $var['tag'] . '" class="add-merge-var" href="javascript:void(0);">*|' . $var['tag'] . '|*</a>',
       );
     }
-    $table = array('rows' => $rows);
-    return render(theme('table', $table));
+    $table = theme('table', array('rows' => $rows));
+    return render($table);
   }
   else {
     return t('No custom merge vars exist for the current list.');

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -124,17 +124,11 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
   }
 
   if (isset($list_id)) {
-    $merge_vars = mailchimp_get_mergevars(array($list_id));
-    if (isset($merge_vars[$list_id])) {
-      $form['content']['merge_vars'] = array(
-        '#type' => 'fieldset',
-        '#title' => 'Merge Tags',
-        '#collapsible' => TRUE,
-        '#collapsed' => TRUE,
-        '#children' => _mailchimp_campaign_build_merge_vars_html(
-          $merge_vars[$list_id]['merge_vars']),
-      );
-    }
+    $merge_vars_list = mailchimp_get_mergevars(array($list_id));
+    $merge_vars = $merge_vars_list[$list_id]['merge_vars'];
+  }
+  else {
+    $merge_vars = array();
   }
 
   $form['content']['entity_import'] = array(
@@ -223,6 +217,14 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
         '#title' => check_plain(drupal_ucfirst($section)),
         '#default_value' => $default_value,
       );
+
+      if (isset($merge_vars)) {
+        $form['content'][$section . '_wrapper']['merge_vars'] = array (
+          '#type' => 'item',
+          '#title' => 'Merge Vars',
+          '#markup' => _mailchimp_campaign_build_merge_vars_html($merge_vars),
+        );
+      }
     }
   }
   else {

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -502,7 +502,7 @@ function _mailchimp_campaign_build_merge_vars_html($merge_vars) {
 /**
  * Parses template content to remove wrapper elements from tree.
  *
- * @param $content
+ * @param array $content
  *   The template content array.
  *
  * @return array

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -364,6 +364,8 @@ function mailchimp_campaign_campaign_form_submit($form, &$form_state) {
  *   Array of item data containing 'id' and 'name' properties.
  * @param string $no_selection_label
  *   The option value to display when no option is selected.
+ * @param array $labels
+ *   Optional associative array of list indexes to custom labels.
  *
  * @return array
  *   Associative array of item IDs to name.
@@ -400,8 +402,6 @@ function mailchimp_campaign_entity_type_callback($form, $form_state) {
   $html = '<div id="' . $entity_import_wrapper . '" class="content-entity-lookup-wrapper">';
   $html .= drupal_render($form['content'][$content_wrapper]['entity_import']['entity_id']);
   $html .= drupal_render($form['content'][$content_wrapper]['entity_import']['entity_view_mode']);
-  // $html .= drupal_render($form['content'][$content_wrapper]['entity_import']['entity_import_tag']);
-  // $html .= drupal_render($form['content'][$content_wrapper]['entity_import']['entity_import_link']);
   $html .= '</div>';
 
   $commands[] = ajax_command_replace('#' . $entity_import_wrapper, $html);

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -131,14 +131,6 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
     $merge_vars = array();
   }
 
-  $form['content']['entity_import'] = array(
-    '#id' => 'entity-import',
-    '#type' => 'fieldset',
-    '#title' => t('Site content import'),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
-  );
-
   $entity_info = _mailchimp_campaign_get_entities_for_content_import();
   $entity_options = _mailchimp_campaign_build_entity_option_list($entity_info);
 
@@ -152,45 +144,7 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
 
   $entity_view_mode_options = _mailchimp_campaign_build_entity_view_mode_option_list($entity_info[$entity_type]);
 
-  $form['content']['entity_import']['entity_type'] = array(
-    '#type' => 'select',
-    '#title' => t('Entity Type'),
-    '#options' => $entity_options,
-    '#default_value' => $entity_type,
-    '#ajax' => array(
-      'callback' => 'mailchimp_campaign_entity_type_callback',
-      'method' => 'replace',
-      'wrapper' => 'content-entity-lookup-wrapper',
-    ),
-  );
-  $form['content']['entity_import']['entity_type']['#attributes']['class'][] = 'entity-import-entity-type';
 
-  $form['content']['entity_import']['entity_id'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Entity Title'),
-    // Pass entity type as first parameter to entity autocomplete callback.
-    '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
-    '#prefix' => '<div id="content-entity-lookup-wrapper">',
-  );
-  $form['content']['entity_import']['entity_id']['#attributes']['class'][] = 'entity-import-entity-id';
-
-  $form['content']['entity_import']['entity_view_mode'] = array(
-    '#type' => 'select',
-    '#title' => t('View Mode'),
-    '#options' => $entity_view_mode_options,
-    '#suffix' => '</div>',
-  );
-  $form['content']['entity_import']['entity_view_mode']['#attributes']['class'][] = 'entity-import-entity-view-mode';
-
-  $form['content']['entity_import']['entity_import_link'] = array(
-    '#type' => 'item',
-    '#markup' => '<a id="add-entity-token" href="javascript:void(0);">Add entity token</a>',
-  );
-
-  $form['content']['entity_import']['entity_import_tag'] = array(
-    '#type' => 'item',
-    '#markup' => '<div id="entity-import-tag-field"></div>',
-  );
 
   if ($mc_template) {
     if (strpos($mc_template['info']['source'], 'mc:repeatable')) {
@@ -225,6 +179,53 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
           '#markup' => _mailchimp_campaign_build_merge_vars_html($merge_vars),
         );
       }
+
+      $form['content'][$section . '_wrapper']['entity_import'] = array(
+        '#id' => 'entity-import',
+        '#type' => 'item',
+        '#title' => t('Site content import'),
+        '#collapsible' => FALSE,
+      );
+
+      $form['content'][$section . '_wrapper']['entity_import']['entity_type'] = array(
+        '#type' => 'select',
+        '#title' => t('Entity Type'),
+        '#options' => $entity_options,
+        '#default_value' => $entity_type,
+        '#ajax' => array(
+          'callback' => 'mailchimp_campaign_entity_type_callback',
+          'method' => 'replace',
+          'wrapper' => 'content-entity-lookup-wrapper',
+        ),
+      );
+      $form['content'][$section . '_wrapper']['entity_import']['entity_type']['#attributes']['class'][] = 'entity-import-entity-type';
+
+      $form['content'][$section . '_wrapper']['entity_import']['entity_id'] = array(
+        '#type' => 'textfield',
+        '#title' => t('Entity Title'),
+        // Pass entity type as first parameter to entity autocomplete callback.
+        '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
+        '#prefix' => '<div id="content-entity-lookup-wrapper">',
+      );
+      $form['content'][$section . '_wrapper']['entity_import']['entity_id']['#attributes']['class'][] = 'entity-import-entity-id';
+
+      $form['content'][$section . '_wrapper']['entity_import']['entity_view_mode'] = array(
+        '#type' => 'select',
+        '#title' => t('View Mode'),
+        '#options' => $entity_view_mode_options,
+        '#suffix' => '</div>',
+      );
+      $form['content'][$section . '_wrapper']['entity_import']['entity_view_mode']['#attributes']['class'][] = 'entity-import-entity-view-mode';
+
+      $form['content'][$section . '_wrapper']['entity_import']['entity_import_link'] = array(
+        '#type' => 'item',
+        '#markup' => '<a id="add-entity-token" href="javascript:void(0);">Add entity token</a>',
+      );
+
+      $form['content'][$section . '_wrapper']['entity_import']['entity_import_tag'] = array(
+        '#type' => 'item',
+        '#markup' => '<div id="entity-import-tag-field"></div>',
+      );
     }
   }
   else {

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -477,28 +477,18 @@ function _mailchimp_campaign_build_entity_view_mode_option_list(array $entity) {
  *   HTML string containing formatted merge vars.
  */
 function _mailchimp_campaign_build_merge_vars_html($merge_vars) {
-  $html = '';
-
   if (!empty($merge_vars)) {
-    $html .= '<table>';
     foreach ($merge_vars as $var) {
-      $html .= '<tr>'
-        . '<td>' . $var['name'] . '</td>'
-        . '<td><a id="merge-var-'
-        . $var['tag'] . '" class="add-merge-var" href="javascript:void(0);">*|' . $var['tag'] . '|*</a></td>'
-        . '</tr>';
+      $rows[] = array(
+        $var['name'],
+        '<a id="merge-var-' . $var['tag'] . '" class="add-merge-var" href="javascript:void(0);">*|' . $var['tag'] . '|*</a>',
+      );
     }
-    $html .= '</table>';
+    return render(theme('table', array('rows' => $rows)));
   }
   else {
-    $html .= t('No custom merge vars exist for the current list.');
+    return t('No custom merge vars exist for the current list.');
   }
-
-  $html .= '<p>' . l(t('Standard MailChimp merge tags are available.'),
-      'http://kb.mailchimp.com/article/all-the-merge-tags-cheatsheet',
-      array('attributes' => array('target' => '_blank'))) . '</p>';
-
-  return $html;
 }
 
 /**

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -212,8 +212,10 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
           '#type' => 'select',
           '#title' => t('View Mode'),
           '#options' => $entity_view_mode_options,
+          '#attributes' => array(
+            'id' => $section . '-entity-import-entity-view-mode',
+          ),
         );
-        $form['content'][$section . '_wrapper']['entity_import']['entity_view_mode']['#attributes']['id'] = $section . '-entity-import-entity-view-mode';
       }
 
       $form['content'][$section . '_wrapper']['entity_import']['entity_import_link'] = array(

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -230,7 +230,17 @@ function mailchimp_campaign_template_callback($form, $form_state) {
  * AJAX callback when changing list ID.
  */
 function mailchimp_campaign_list_segment_callback($form, $form_state) {
-  return $form['list_segment_id'];
+  $commands = array();
+
+  $list_segment_html = drupal_render($form['list_segment_id']);
+  $commands[] = ajax_command_replace('#list-segments-wrapper', $list_segment_html);
+
+  if (isset($form['content']['html_wrapper']['merge_vars'])) {
+    $merge_vars_html = drupal_render($form['content']['html_wrapper']['merge_vars']);
+    $commands[] = ajax_command_replace('.merge-vars-wrapper', $merge_vars_html);
+  }
+
+  return array('#type' => 'ajax', '#commands' => $commands);
 }
 
 /**
@@ -400,6 +410,15 @@ function mailchimp_campaign_get_merge_vars_form_elements($merge_vars, $list_name
   $form = array();
 
   $form['merge_vars'] = array(
+    '#type' => 'container',
+    '#attributes' => array(
+      'class' => array(
+        'merge-vars-wrapper'
+      ),
+    ),
+  );
+
+  $form['merge_vars']['content'] = array(
     '#type' => 'item',
     '#title' => 'MailChimp merge variables',
     '#markup' => _mailchimp_campaign_build_merge_vars_html($merge_vars),

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -447,7 +447,10 @@ function _mailchimp_campaign_build_entity_option_list($entity_info) {
     '' => '-- Select --',
   );
   foreach ($entity_info as $entity_id => $entity_data) {
-    $options[$entity_id] = $entity_data['label'];
+    // Exclude MailChimp entities.
+    if (strpos($entity_id, 'mailchimp') === FALSE) {
+      $options[$entity_id] = $entity_data['label'];
+    }
   }
 
   return $options;

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -171,8 +171,7 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
         '#collapsible' => FALSE,
         '#states' => array(
           'visible' => array(
-            ':input[name="content[' . $section . '_wrapper][' . $section . '][format]"]' =>
-              array('value' => 'mailchimp_campaign'),
+            ':input[name="content[' . $section . '_wrapper][' . $section . '][format]"]' => array('value' => 'mailchimp_campaign'),
           ),
         ),
       );
@@ -202,7 +201,7 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
         $form['content'][$section . '_wrapper']['entity_import']['entity_id'] = array(
           '#type' => 'textfield',
           '#title' => t('Entity Title'),
-          // Pass entity type as first parameter to entity autocomplete callback.
+          // Pass entity type as first parameter to autocomplete callback.
           '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
         );
         $form['content'][$section . '_wrapper']['entity_import']['entity_id']['#attributes']['id'] = $section . '-entity-import-entity-id';
@@ -220,8 +219,7 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
         '#markup' => '<a id="' . $section . '-add-entity-token-link" class="add-entity-token-link" href="javascript:void(0);">Add entity token test</a>',
         '#states' => array(
           'invisible' => array(
-            ':input[name="content[' . $section . '_wrapper][entity_import][entity_type]"]' =>
-              array('value' => ''),
+            ':input[name="content[' . $section . '_wrapper][entity_import][entity_type]"]' => array('value' => ''),
           ),
         ),
       );
@@ -231,8 +229,7 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
         '#markup' => '<div id="' . $section . '-entity-import-tag-field" class="' . $section . '-entity-import-tag-field"></div>',
         '#states' => array(
           'invisible' => array(
-            ':input[name="content[' . $section . '_wrapper][entity_import][entity_type]"]' =>
-              array('value' => ''),
+            ':input[name="content[' . $section . '_wrapper][entity_import][entity_type]"]' => array('value' => ''),
           ),
         ),
       );

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -161,91 +161,13 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
       $entity_type = isset($form_state['values']['content'][$section . '_wrapper']['entity_import']['entity_type']) ?
         $form_state['values']['content'][$section . '_wrapper']['entity_import']['entity_type'] : NULL;
 
-      // Get available entity types.
-      $entity_info = _mailchimp_campaign_get_entities_for_content_import();
-      $entity_options = _mailchimp_campaign_build_entity_option_list($entity_info);
-
-      $form['content'][$section . '_wrapper']['entity_import'] = array(
-        '#id' => 'entity-import',
-        '#type' => 'fieldset',
-        '#title' => t('Insert site content'),
-        '#description' => t('You can insert an entity of a given type and pick the view mode that will be rendered within this campaign section.'),
-        '#collapsible' => FALSE,
-        '#states' => array(
-          'visible' => array(
-            ':input[name="content[' . $section . '_wrapper][' . $section . '][format]"]' => array('value' => 'mailchimp_campaign'),
-          ),
-        ),
-      );
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_type'] = array(
-        '#type' => 'select',
-        '#title' => t('Entity Type'),
-        '#options' => $entity_options,
-        '#default_value' => $entity_type,
-        '#ajax' => array(
-          'callback' => 'mailchimp_campaign_entity_type_callback',
-          'wrapper' => $section . '-content-entity-lookup-wrapper',
-        ),
-      );
-      $form['content'][$section . '_wrapper']['entity_import']['entity_type']['#attributes']['class'][] = $section . '-entity-import-entity-type';
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_import_wrapper'] = array(
-        '#type' => 'container',
-        '#attributes' => array(
-          'id' => $section . '-content-entity-lookup-wrapper',
-        ),
-      );
-
-      if ($entity_type != NULL) {
-        // Get available entity view modes.
-        $entity_view_mode_options = _mailchimp_campaign_build_entity_view_mode_option_list($entity_info[$entity_type]);
-
-        $form['content'][$section . '_wrapper']['entity_import']['entity_id'] = array(
-          '#type' => 'textfield',
-          '#title' => t('Entity Title'),
-          // Pass entity type as first parameter to autocomplete callback.
-          '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
-        );
-        $form['content'][$section . '_wrapper']['entity_import']['entity_id']['#attributes']['id'] = $section . '-entity-import-entity-id';
-
-        $form['content'][$section . '_wrapper']['entity_import']['entity_view_mode'] = array(
-          '#type' => 'select',
-          '#title' => t('View Mode'),
-          '#options' => $entity_view_mode_options,
-          '#attributes' => array(
-            'id' => $section . '-entity-import-entity-view-mode',
-          ),
-        );
-      }
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_import_link'] = array(
-        '#type' => 'item',
-        '#markup' => '<a id="' . $section . '-add-entity-token-link" class="add-entity-token-link" href="javascript:void(0);">' . t('Insert entity token') . '</a>',
-        '#states' => array(
-          'invisible' => array(
-            ':input[name="content[' . $section . '_wrapper][entity_import][entity_type]"]' => array('value' => ''),
-          ),
-        ),
-      );
-
-      $form['content'][$section . '_wrapper']['merge_vars'] = array(
-        '#type' => 'item',
-        '#title' => 'MailChimp merge variables',
-        '#markup' => _mailchimp_campaign_build_merge_vars_html($merge_vars),
-        '#description' => t(
-          'Insert merge variables from the the %list_name list or one of the !standard_link.',
-          array(
-            '%list_name' => $mailchimp_lists[$list_id]['name'],
-            '!standard_link' => l(
-              t('standard MailChimp merge variables'), 'http://kb.mailchimp.com/article/all-the-merge-tags-cheatsheet',
-              array('attributes' => array('target' => '_blank'))),
-          )
-        ),
-      );
+      $form['content'][$section . '_wrapper'] += mailchimp_campaign_get_entity_import_form_elements($entity_type, $section);
+      $form['content'][$section . '_wrapper'] += mailchimp_campaign_get_merge_vars_form_elements($merge_vars, $mailchimp_lists[$list_id]['name']);
     }
   }
   else {
+    $section = 'html';
+
     $form['content']['html_wrapper'] = array(
       '#type' => 'fieldset',
       '#title' => t('Content'),
@@ -260,6 +182,14 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
       '#access' => empty($form_state['values']['template_id']),
       '#default_value' => ($campaign) ? $campaign->template['html']['value'] : '',
     );
+
+    $entity_type = isset($form_state['values']['content'][$section . '_wrapper']['entity_import']['entity_type']) ?
+      $form_state['values']['content'][$section . '_wrapper']['entity_import']['entity_type'] : NULL;
+
+    $form['content'][$section . '_wrapper'] += mailchimp_campaign_get_entity_import_form_elements($entity_type, $section);
+
+    $list_name = (!empty($list_id)) ? $mailchimp_lists[$list_id]['name'] : '';
+    $form['content'][$section . '_wrapper'] += mailchimp_campaign_get_merge_vars_form_elements($merge_vars, $list_name);
   }
 
   // Message preview:
@@ -358,6 +288,154 @@ function mailchimp_campaign_campaign_form_submit($form, &$form_state) {
 }
 
 /**
+ * Gets form elements used in the entity import feature.
+ *
+ * @param string $entity_type
+ *   The type of entity to import.
+ * @param string $section
+ *   The content section these fields are displayed in.
+ *
+ * @return array
+ *   Array of form elements used to display entity imports.
+ */
+function mailchimp_campaign_get_entity_import_form_elements($entity_type, $section) {
+  $form = array();
+
+  // Get available entity types.
+  $entity_info = _mailchimp_campaign_get_entities_for_content_import();
+  $entity_options = _mailchimp_campaign_build_entity_option_list($entity_info);
+
+  $form['entity_import'] = array(
+    '#id' => 'entity-import',
+    '#type' => 'fieldset',
+    '#title' => t('Insert site content'),
+    '#description' => t('You can insert an entity of a given type and pick the view mode that will be rendered within this campaign section.'),
+    '#collapsible' => FALSE,
+    '#states' => array(
+      'visible' => array(
+        ':input[name="content[' . $section . '_wrapper][' . $section . '][format]"]' => array('value' => 'mailchimp_campaign'),
+      ),
+    ),
+  );
+
+  $form['entity_import']['entity_type'] = array(
+    '#type' => 'select',
+    '#title' => t('Entity Type'),
+    '#options' => $entity_options,
+    '#default_value' => $entity_type,
+    '#ajax' => array(
+      'callback' => 'mailchimp_campaign_entity_type_callback',
+      'wrapper' => $section . '-content-entity-lookup-wrapper',
+    ),
+  );
+  $form['entity_import']['entity_type']['#attributes']['class'][] = $section . '-entity-import-entity-type';
+
+  $form['entity_import']['entity_import_wrapper'] = array(
+    '#type' => 'container',
+    '#attributes' => array(
+      'id' => $section . '-content-entity-lookup-wrapper',
+    ),
+  );
+
+  if ($entity_type != NULL) {
+    // Get available entity view modes.
+    $entity_view_mode_options = _mailchimp_campaign_build_entity_view_mode_option_list($entity_info[$entity_type]);
+
+    $form['entity_import']['entity_id'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Entity Title'),
+      // Pass entity type as first parameter to autocomplete callback.
+      '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
+    );
+    $form['entity_import']['entity_id']['#attributes']['id'] = $section . '-entity-import-entity-id';
+
+    $form['entity_import']['entity_view_mode'] = array(
+      '#type' => 'select',
+      '#title' => t('View Mode'),
+      '#options' => $entity_view_mode_options,
+      '#attributes' => array(
+        'id' => $section . '-entity-import-entity-view-mode',
+      ),
+    );
+  }
+
+  $form['entity_import']['entity_import_link'] = array(
+    '#type' => 'item',
+    '#markup' => '<a id="' . $section . '-add-entity-token-link" class="add-entity-token-link" href="javascript:void(0);">' . t('Insert entity token') . '</a>',
+    '#states' => array(
+      'invisible' => array(
+        ':input[name="content[' . $section . '_wrapper][entity_import][entity_type]"]' => array('value' => ''),
+      ),
+    ),
+  );
+
+  $form['entity_import']['entity_import_tag'] = array(
+    '#type' => 'container',
+    '#attributes' => array(
+      'id' => $section . '-entity-import-tag-field',
+    ),
+    '#states' => array(
+      'invisible' => array(
+        ':input[name="content[' . $section . '_wrapper][entity_import][entity_type]"]' => array('value' => ''),
+      ),
+    ),
+  );
+
+  return $form;
+}
+
+/**
+ * Gets form elements used in the merge vars feature.
+ *
+ * @param array $merge_vars
+ *   Array of MailChimp merge vars for the current list.
+ * @see mailchimp_get_mergevars
+ * @param string $list_name
+ *   The name of the current list.
+ *
+ * @return array
+ *   Array of form elements used to display merge vars.
+ */
+function mailchimp_campaign_get_merge_vars_form_elements($merge_vars, $list_name) {
+  $form = array();
+
+  $form['merge_vars'] = array(
+    '#type' => 'item',
+    '#title' => 'MailChimp merge variables',
+    '#markup' => _mailchimp_campaign_build_merge_vars_html($merge_vars),
+    '#description' => t(
+      'Insert merge variables from the %list_name list or one of the !standard_link.',
+      array(
+        '%list_name' => $list_name,
+        '!standard_link' => l(
+          t('standard MailChimp merge variables'), 'http://kb.mailchimp.com/article/all-the-merge-tags-cheatsheet',
+          array('attributes' => array('target' => '_blank'))),
+      )
+    ),
+  );
+
+  return $form;
+}
+
+/**
+ * AJAX callback when changing entity type.
+ */
+function mailchimp_campaign_entity_type_callback($form, $form_state) {
+  $commands = array();
+
+  $content_wrapper = $form_state['triggering_element']['#parents'][1];
+  $entity_import_wrapper = $form_state['triggering_element']['#ajax']['wrapper'];
+
+  $html = '<div id="' . $entity_import_wrapper . '" class="content-entity-lookup-wrapper">';
+  $html .= drupal_render($form['content'][$content_wrapper]['entity_import']['entity_id']);
+  $html .= drupal_render($form['content'][$content_wrapper]['entity_import']['entity_view_mode']);
+  $html .= '</div>';
+
+  $commands[] = ajax_command_replace('#' . $entity_import_wrapper, $html);
+  return array('#type' => 'ajax', '#commands' => $commands);
+}
+
+/**
  * Returns an options list for a given array of items.
  *
  * @param array $list
@@ -388,24 +466,6 @@ function _mailchimp_campaign_build_option_list($list, $no_selection_label = '-- 
   }
 
   return $options;
-}
-
-/**
- * AJAX callback when changing entity type.
- */
-function mailchimp_campaign_entity_type_callback($form, $form_state) {
-  $commands = array();
-
-  $content_wrapper = $form_state['triggering_element']['#parents'][1];
-  $entity_import_wrapper = $form_state['triggering_element']['#ajax']['wrapper'];
-
-  $html = '<div id="' . $entity_import_wrapper . '" class="content-entity-lookup-wrapper">';
-  $html .= drupal_render($form['content'][$content_wrapper]['entity_import']['entity_id']);
-  $html .= drupal_render($form['content'][$content_wrapper]['entity_import']['entity_view_mode']);
-  $html .= '</div>';
-
-  $commands[] = ajax_command_replace('#' . $entity_import_wrapper, $html);
-  return array('#type' => 'ajax', '#commands' => $commands);
 }
 
 /**

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -131,21 +131,6 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
     $merge_vars = array();
   }
 
-  $entity_info = _mailchimp_campaign_get_entities_for_content_import();
-  $entity_options = _mailchimp_campaign_build_entity_option_list($entity_info);
-
-  if (!empty($form_state['values']['content']['entity_import']['entity_type'])) {
-    $entity_type = $form_state['values']['content']['entity_import']['entity_type'];
-  }
-  else {
-    reset($entity_options);
-    $entity_type = current(array_keys($entity_options));
-  }
-
-  $entity_view_mode_options = _mailchimp_campaign_build_entity_view_mode_option_list($entity_info[$entity_type]);
-
-
-
   if ($mc_template) {
     if (strpos($mc_template['info']['source'], 'mc:repeatable')) {
       drupal_set_message(t('WARNING: This template has repeating sections, which are not supported. You may want to select a different template.'), 'warning');
@@ -172,59 +157,10 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
         '#default_value' => $default_value,
       );
 
-      if (isset($merge_vars)) {
-        $form['content'][$section . '_wrapper']['merge_vars'] = array (
-          '#type' => 'item',
-          '#title' => 'Merge Vars',
-          '#markup' => _mailchimp_campaign_build_merge_vars_html($merge_vars),
-        );
-      }
-
-      $form['content'][$section . '_wrapper']['entity_import'] = array(
-        '#id' => 'entity-import',
+      $form['content'][$section . '_wrapper']['merge_vars'] = array(
         '#type' => 'item',
-        '#title' => t('Site content import'),
-        '#collapsible' => FALSE,
-      );
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_type'] = array(
-        '#type' => 'select',
-        '#title' => t('Entity Type'),
-        '#options' => $entity_options,
-        '#default_value' => $entity_type,
-        '#ajax' => array(
-          'callback' => 'mailchimp_campaign_entity_type_callback',
-          'method' => 'replace',
-          'wrapper' => 'content-entity-lookup-wrapper',
-        ),
-      );
-      $form['content'][$section . '_wrapper']['entity_import']['entity_type']['#attributes']['class'][] = 'entity-import-entity-type';
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_id'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Entity Title'),
-        // Pass entity type as first parameter to entity autocomplete callback.
-        '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
-        '#prefix' => '<div id="content-entity-lookup-wrapper">',
-      );
-      $form['content'][$section . '_wrapper']['entity_import']['entity_id']['#attributes']['class'][] = 'entity-import-entity-id';
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_view_mode'] = array(
-        '#type' => 'select',
-        '#title' => t('View Mode'),
-        '#options' => $entity_view_mode_options,
-        '#suffix' => '</div>',
-      );
-      $form['content'][$section . '_wrapper']['entity_import']['entity_view_mode']['#attributes']['class'][] = 'entity-import-entity-view-mode';
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_import_link'] = array(
-        '#type' => 'item',
-        '#markup' => '<a id="add-entity-token" href="javascript:void(0);">Add entity token</a>',
-      );
-
-      $form['content'][$section . '_wrapper']['entity_import']['entity_import_tag'] = array(
-        '#type' => 'item',
-        '#markup' => '<div id="entity-import-tag-field"></div>',
+        '#title' => 'Merge Vars',
+        '#markup' => _mailchimp_campaign_build_merge_vars_html($merge_vars),
       );
     }
   }
@@ -351,67 +287,6 @@ function mailchimp_campaign_campaign_form_submit($form, &$form_state) {
   cache_clear_all('mailchimp_campaign_campaigns', 'cache');
 
   $form_state['redirect'][] = 'admin/config/services/mailchimp/campaigns';
-}
-
-/**
- * Returns an array of entities based on data from entity_get_info().
- *
- * Filters out entities that do not contain a title field, as they cannot
- * be used to import content into templates.
- *
- * @return array
- *   Filtered entities from entity_get_info().
- */
-function _mailchimp_campaign_get_entities_for_content_import() {
-  $entity_info = entity_get_info();
-
-  $filtered_entities = array();
-  foreach ($entity_info as $key => $entity) {
-    if (in_array('title', $entity['schema_fields_sql']['base table'])) {
-      $filtered_entities[$key] = $entity;
-    }
-  }
-
-  return $filtered_entities;
-}
-
-/**
- * Returns an options list of entities based on data from entity_get_info().
- *
- * Filters out entities that do not contain a title field, as they cannot
- * be used to import content into templates.
- *
- * @param array $entity_info
- *   Array of entities as returned by entity_get_info().
- *
- * @return array
- *   Associative array of entity IDs to name.
- */
-function _mailchimp_campaign_build_entity_option_list($entity_info) {
-  $options = array();
-  foreach ($entity_info as $entity_id => $entity_data) {
-    $options[$entity_id] = $entity_data['label'];
-  }
-
-  return $options;
-}
-
-/**
- * Returns an options list of entity view modes.
- *
- * @param array $entity
- *   Array of entity data as returned by entity_get_info().
- *
- * @return array
- *   Associative array of view mode IDs to name.
- */
-function _mailchimp_campaign_build_entity_view_mode_option_list(array $entity) {
-  $options = array();
-  foreach ($entity['view modes'] as $view_mode_id => $view_mode_data) {
-    $options[$view_mode_id] = $view_mode_data['label'];
-  }
-
-  return $options;
 }
 
 /**

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -501,7 +501,8 @@ function _mailchimp_campaign_build_merge_vars_html($merge_vars) {
         '<a id="merge-var-' . $var['tag'] . '" class="add-merge-var" href="javascript:void(0);">*|' . $var['tag'] . '|*</a>',
       );
     }
-    return render(theme('table', array('rows' => $rows)));
+    $table = array('rows' => $rows);
+    return render(theme('table', $table));
   }
   else {
     return t('No custom merge vars exist for the current list.');

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -157,6 +157,87 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
         '#default_value' => $default_value,
       );
 
+      $entity_type = isset($form_state['values']['content'][ $section . '_wrapper']['entity_import']['entity_type']) ?
+        $form_state['values']['content'][ $section . '_wrapper']['entity_import']['entity_type'] : NULL;
+
+      // Get available entity types.
+      $entity_info = _mailchimp_campaign_get_entities_for_content_import();
+      $entity_options = _mailchimp_campaign_build_entity_option_list($entity_info);
+
+      $form['content'][$section . '_wrapper']['entity_import'] = array(
+        '#id' => 'entity-import',
+        '#type' => 'fieldset',
+        '#title' => t('Site Content Import'),
+        '#collapsible' => FALSE,
+        '#states' => array(
+          'visible' => array(
+            ':input[name="content[' . $section . '_wrapper][' . $section . '][format]"]' =>
+              array('value' => 'mailchimp_campaign'),
+          ),
+        ),
+      );
+
+      $form['content'][$section . '_wrapper']['entity_import']['entity_type'] = array(
+        '#type' => 'select',
+        '#title' => t('Entity Type'),
+        '#options' => $entity_options,
+        '#default_value' => $entity_type,
+        '#ajax' => array(
+          'callback' => 'mailchimp_campaign_entity_type_callback',
+          'wrapper' => $section . '-content-entity-lookup-wrapper',
+        ),
+      );
+      $form['content'][$section . '_wrapper']['entity_import']['entity_type']['#attributes']['class'][] = $section . '-entity-import-entity-type';
+
+      $form['content'][$section . '_wrapper']['entity_import']['entity_import_wrapper'] = array(
+        '#type' => 'item',
+        '#prefix' => '<div id="' . $section . '-content-entity-lookup-wrapper">',
+        '#suffix' => '</div>',
+      );
+
+      if ($entity_type != NULL) {
+        // Get available entity view modes.
+        $entity_view_mode_options = _mailchimp_campaign_build_entity_view_mode_option_list($entity_info[$entity_type]);
+
+        $form['content'][$section . '_wrapper']['entity_import']['entity_id'] = array(
+          '#type' => 'textfield',
+          '#title' => t('Entity Title'),
+          // Pass entity type as first parameter to entity autocomplete callback.
+          '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
+        );
+        $form['content'][$section . '_wrapper']['entity_import']['entity_id']['#attributes']['id'] = $section . '-entity-import-entity-id';
+
+        $form['content'][$section . '_wrapper']['entity_import']['entity_view_mode'] = array(
+          '#type' => 'select',
+          '#title' => t('View Mode'),
+          '#options' => $entity_view_mode_options,
+        );
+        $form['content'][$section . '_wrapper']['entity_import']['entity_view_mode']['#attributes']['id'] = $section . '-entity-import-entity-view-mode';
+      }
+
+      $form['content'][$section . '_wrapper']['entity_import']['entity_import_link'] = array(
+        '#type' => 'item',
+        '#markup' => '<a id="' . $section . '-add-entity-token-link" class="add-entity-token-link" href="javascript:void(0);">Add entity token test</a>',
+        '#states' => array(
+          'invisible' => array(
+            ':input[name="content[' . $section . '_wrapper][entity_import][entity_type]"]' =>
+              array('value' => ''),
+          ),
+        ),
+      );
+
+      $form['content'][$section . '_wrapper']['entity_import']['entity_import_tag'] = array(
+        '#type' => 'item',
+        '#markup' => '<div id="' . $section . '-entity-import-tag-field" class="' . $section . '-entity-import-tag-field"></div>',
+        '#states' => array(
+          'invisible' => array(
+            ':input[name="content[' . $section . '_wrapper][entity_import][entity_type]"]' =>
+              array('value' => ''),
+          ),
+        ),
+      );
+      $form['content'][$section . '_wrapper']['entity_import']['entity_import_tag']['#attributes']['class'][] = 'entity-import-entity-import-tag';
+
       $form['content'][$section . '_wrapper']['merge_vars'] = array(
         '#type' => 'item',
         '#title' => 'Merge Vars',
@@ -220,19 +301,6 @@ function mailchimp_campaign_template_callback($form, $form_state) {
  */
 function mailchimp_campaign_list_segment_callback($form, $form_state) {
   return $form['list_segment_id'];
-}
-
-/**
- * AJAX callback when changing entity type.
- *
- * @return array
- *   Entity form elements array.
- */
-function mailchimp_campaign_entity_type_callback($form, $form_state) {
-  return array(
-    $form['content']['entity_import']['entity_id'],
-    $form['content']['entity_import']['entity_view_mode'],
-  );
 }
 
 /**
@@ -321,6 +389,88 @@ function _mailchimp_campaign_build_option_list($list, $no_selection_label = '-- 
 }
 
 /**
+ * AJAX callback when changing entity type.
+ */
+function mailchimp_campaign_entity_type_callback($form, $form_state) {
+  $commands = array();
+
+  $content_wrapper = $form_state['triggering_element']['#parents'][1];
+  $entity_import_wrapper = $form_state['triggering_element']['#ajax']['wrapper'];
+
+  $html = '<div id="' . $entity_import_wrapper . '" class="content-entity-lookup-wrapper">';
+  $html .= drupal_render($form['content'][$content_wrapper]['entity_import']['entity_id']);
+  $html .= drupal_render($form['content'][$content_wrapper]['entity_import']['entity_view_mode']);
+  // $html .= drupal_render($form['content'][$content_wrapper]['entity_import']['entity_import_tag']);
+  // $html .= drupal_render($form['content'][$content_wrapper]['entity_import']['entity_import_link']);
+  $html .= '</div>';
+
+  $commands[] = ajax_command_replace('#' . $entity_import_wrapper, $html);
+  return array('#type' => 'ajax', '#commands' => $commands);
+}
+
+/**
+ * Returns an array of entities based on data from entity_get_info().
+ *
+ * Filters out entities that do not contain a title field, as they cannot
+ * be used to import content into templates.
+ *
+ * @return array
+ *   Filtered entities from entity_get_info().
+ */
+function _mailchimp_campaign_get_entities_for_content_import() {
+  $entity_info = entity_get_info();
+
+  foreach ($entity_info as $key => $entity) {
+    if (in_array('title', $entity['schema_fields_sql']['base table'])) {
+      $filtered_entities[$key] = $entity;
+    }
+  }
+
+  return $filtered_entities;
+}
+
+/**
+ * Returns an options list of entities based on data from entity_get_info().
+ *
+ * Filters out entities that do not contain a title field, as they cannot
+ * be used to import content into templates.
+ *
+ * @param array $entity_info
+ *   Array of entities as returned by entity_get_info().
+ *
+ * @return array
+ *   Associative array of entity IDs to name.
+ */
+function _mailchimp_campaign_build_entity_option_list($entity_info) {
+  $options = array(
+    '' => '-- Select --',
+  );
+  foreach ($entity_info as $entity_id => $entity_data) {
+    $options[$entity_id] = $entity_data['label'];
+  }
+
+  return $options;
+}
+
+/**
+ * Returns an options list of entity view modes.
+ *
+ * @param array $entity
+ *   Array of entity data as returned by entity_get_info().
+ *
+ * @return array
+ *   Associative array of view mode IDs to name.
+ */
+function _mailchimp_campaign_build_entity_view_mode_option_list(array $entity) {
+  $options = array();
+  foreach ($entity['view modes'] as $view_mode_id => $view_mode_data) {
+    $options[$view_mode_id] = $view_mode_data['label'];
+  }
+
+  return $options;
+}
+
+/**
  * Builds a HTML string used to render merge vars on the campaign form.
  *
  * @param array $merge_vars
@@ -401,7 +551,7 @@ function mailchimp_campaign_delete_form_submit($form, &$form_state) {
   $campaign = $form_state['campaign'];
   if (mailchimp_campaign_delete_campaign($campaign->mc_campaign_id)) {
     drupal_set_message(t('Campaign %name has been deleted.',
-      array('%name' => $campaign->label()))
+        array('%name' => $campaign->label()))
     );
   }
   drupal_goto('admin/config/services/mailchimp/campaigns');

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.admin.inc
@@ -190,9 +190,10 @@ function mailchimp_campaign_campaign_form($form, &$form_state, MailChimpCampaign
       $form['content'][$section . '_wrapper']['entity_import']['entity_type']['#attributes']['class'][] = $section . '-entity-import-entity-type';
 
       $form['content'][$section . '_wrapper']['entity_import']['entity_import_wrapper'] = array(
-        '#type' => 'item',
-        '#prefix' => '<div id="' . $section . '-content-entity-lookup-wrapper">',
-        '#suffix' => '</div>',
+        '#type' => 'container',
+        '#attributes' => array(
+          'id' => $section . '-content-entity-lookup-wrapper',
+        ),
       );
 
       if ($entity_type != NULL) {

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.controller.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.controller.inc
@@ -22,7 +22,7 @@ class MailChimpCampaignController extends EntityAPIController {
     foreach ($campaigns as $mc_campaign_id => $campaign) {
       $campaign->mc_data = $mc_campaigns[$mc_campaign_id];
 
-      // Lists are cachced separately, but we want to load them here.
+      // Lists are cached separately, but we want to load them here.
       if (isset($campaign->mc_data['list_id']) && $campaign->mc_data['list_id']) {
         $campaign->list = mailchimp_get_list($campaign->mc_data['list_id']);
       }

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.controller.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.controller.inc
@@ -59,4 +59,15 @@ class MailChimpCampaignController extends EntityAPIController {
     }
   }
 
+  /**
+   * Overrides EntityAPIController::buildQuery().
+   *
+   * Implement to order by created date since our IDs are not numeric.
+   */
+  protected function buildQuery($ids, $conditions = array(), $revision_id = FALSE) {
+    $query = parent::buildQuery($ids, $conditions, $revision_id);
+    $query->orderBy('created', 'DESC');
+    return $query;
+  }
+
 }

--- a/modules/mailchimp_campaign/includes/mailchimp_campaign.controller.inc
+++ b/modules/mailchimp_campaign/includes/mailchimp_campaign.controller.inc
@@ -52,11 +52,10 @@ class MailChimpCampaignController extends EntityAPIController {
           }
         }
       }
-      // Reset all campaigns.
-      else {
-        $cached_campaigns = NULL;
-      }
-      cache_set('campaigns', $cached_campaigns, 'cache_mailchimp');
+
+      $cache_data = (isset($cached_campaigns)) ? $cached_campaigns->data : NULL;
+
+      cache_set('campaigns', $cache_data, 'cache_mailchimp');
     }
   }
 

--- a/modules/mailchimp_campaign/js/mailchimp_campaign.utils.js
+++ b/modules/mailchimp_campaign/js/mailchimp_campaign.utils.js
@@ -24,13 +24,16 @@
       /**
        * Add entity token click handler.
        */
-      $('#add-entity-token', context).unbind('click').bind('click', function() {
+      $('.add-entity-token', context).unbind('click').bind('click', function() {
+        var element_id = $(this).attr('id');
+        var element_tag = element_id.replace('add-entity-token-', '');
+
         // Get the last selected text field.
         var target_element = Drupal.settings.mailchimpCampaignFocusedField;
 
         // Get the selected entity ID.
         var entity_id = '';
-        var entity_value = $('.entity-import-entity-id').val();
+        var entity_value = $('#entity-import-entity-id-' + element_tag).val();
         if ((entity_value) && (entity_value.length > 0)) {
           var entity_parts = entity_value.split(' ');
           var entity_id_string = entity_parts[entity_parts.length - 1];
@@ -44,8 +47,8 @@
         }
 
         // Generate token based on user input.
-        var entity_type = $('.entity-import-entity-type').val();
-        var view_mode = $('.entity-import-entity-view-mode').val();
+        var entity_type = $('#entity-import-entity-type-' + element_tag).val();
+        var view_mode = $('#entity-import-entity-view-mode-' + element_tag).val();
 
         var token = '[mailchimp_campaign'
           + '|entity_type=' + entity_type
@@ -60,8 +63,9 @@
           Drupal.behaviors.mailchimp_campaign_utils.addTokenToElement(target_element, token);
         }
         else {
-          // Insert token into token field, where it can be manually copied by the user.
-          $('#entity-import-tag-field').html(token);
+          // Missing a selected text field. Insert token into token field,
+          // where it can be manually copied by the user.
+          $('#entity-import-tag-field-' + element_tag).html(token);
           $('#edit-content-entity-import-entity-import-tag').show();
         }
 

--- a/modules/mailchimp_campaign/js/mailchimp_campaign.utils.js
+++ b/modules/mailchimp_campaign/js/mailchimp_campaign.utils.js
@@ -12,9 +12,6 @@
    */
   Drupal.behaviors.mailchimp_campaign_utils = {
     attach: function(context, settings) {
-      // Start with import tag field hidden.
-      $('#edit-content-entity-import-entity-import-tag').hide();
-
       // Keep track of which textfield was last selected/focused.
       $('textarea', context).focus(function() {
         Drupal.settings.mailchimpCampaignFocusedField = this;
@@ -24,16 +21,19 @@
       /**
        * Add entity token click handler.
        */
-      $('.add-entity-token', context).unbind('click').bind('click', function() {
+      $('.add-entity-token-link', context).unbind('click').bind('click', function() {
         var element_id = $(this).attr('id');
-        var element_tag = element_id.replace('add-entity-token-', '');
+        var section = element_id.replace('-add-entity-token-link', '');
+
+        // Start with import tag field hidden.
+        $('#' + section + '-entity-import-tag-field').hide();
 
         // Get the last selected text field.
         var target_element = Drupal.settings.mailchimpCampaignFocusedField;
 
         // Get the selected entity ID.
         var entity_id = '';
-        var entity_value = $('#entity-import-entity-id-' + element_tag).val();
+        var entity_value = $('#' + section + '-entity-import-entity-id').val();
         if ((entity_value) && (entity_value.length > 0)) {
           var entity_parts = entity_value.split(' ');
           var entity_id_string = entity_parts[entity_parts.length - 1];
@@ -47,8 +47,8 @@
         }
 
         // Generate token based on user input.
-        var entity_type = $('#entity-import-entity-type-' + element_tag).val();
-        var view_mode = $('#entity-import-entity-view-mode-' + element_tag).val();
+        var entity_type = $('.' + section + '-entity-import-entity-type').val();
+        var view_mode = $('#' + section + '-entity-import-entity-view-mode').val();
 
         var token = '[mailchimp_campaign'
           + '|entity_type=' + entity_type
@@ -65,8 +65,8 @@
         else {
           // Missing a selected text field. Insert token into token field,
           // where it can be manually copied by the user.
-          $('#entity-import-tag-field-' + element_tag).html(token);
-          $('#edit-content-entity-import-entity-import-tag').show();
+          $('#' + section + '-entity-import-tag-field').html(token);
+          $('#' + section + '-entity-import-tag-field').show();
         }
 
         // Unset last focused field.

--- a/modules/mailchimp_campaign/mailchimp_campaign.css
+++ b/modules/mailchimp_campaign/mailchimp_campaign.css
@@ -1,4 +1,4 @@
-fieldset#entity-import .form-type-select, fieldset#entity-import .form-type-textfield, #content-entity-lookup-wrapper {
+div#entity-import .form-type-select, div#entity-import .form-type-textfield, #content-entity-lookup-wrapper {
     display: inline-block;
     margin-right:10px;
 }

--- a/modules/mailchimp_campaign/mailchimp_campaign.css
+++ b/modules/mailchimp_campaign/mailchimp_campaign.css
@@ -1,6 +1,10 @@
-fieldset#entity-import .form-type-select, div#entity-import .form-type-textfield, div#content-entity-lookup-wrapper, div.form-item-entity-id {
+fieldset#entity-import .form-type-select, fieldset#entity-import .form-type-textfield, div.content-entity-lookup-wrapper {
     display: inline-block;
     margin-right: 10px!important;
+}
+
+fieldset#entity-import .form-item {
+    padding: 0!important;
 }
 
 div.form-type-item {

--- a/modules/mailchimp_campaign/mailchimp_campaign.css
+++ b/modules/mailchimp_campaign/mailchimp_campaign.css
@@ -1,4 +1,14 @@
-div#entity-import .form-type-select, div#entity-import .form-type-textfield, #content-entity-lookup-wrapper {
+fieldset#entity-import .form-type-select, div#entity-import .form-type-textfield, div#content-entity-lookup-wrapper, div.form-item-entity-id {
     display: inline-block;
-    margin-right:10px;
+    margin-right: 10px!important;
+}
+
+div.form-type-item {
+    clear: both;
+    margin: 5px auto 5px auto!important;
+}
+
+div.filter-guidelines-mailchimp_campaign ul.tips li {
+    list-style-type: none;
+    margin: 0!important;
 }

--- a/modules/mailchimp_campaign/mailchimp_campaign.module
+++ b/modules/mailchimp_campaign/mailchimp_campaign.module
@@ -568,7 +568,8 @@ function mailchimp_campaign_filter_tips($filter, $format, $long) {
     array('%pattern' => '[mailchimp_campaign|entity_type=node|entity_id=1|view_mode=teaser]')
   );
 
-  $tip .= drupal_render(drupal_get_form('_mailchimp_campaign_get_entity_import_form'));
+  $entity_import_form = drupal_get_form('_mailchimp_campaign_get_entity_import_form');
+  $tip .= drupal_render($entity_import_form);
 
   return $tip;
 }
@@ -580,6 +581,8 @@ function _mailchimp_campaign_get_entity_import_form($form, &$form_state) {
   $entity_type = current(array_keys($entity_options));
 
   $entity_view_mode_options = _mailchimp_campaign_build_entity_view_mode_option_list($entity_info[$entity_type]);
+
+  $element_tag = uniqid();
 
   $form['entity_import'] = array(
     '#id' => 'entity-import',
@@ -599,7 +602,7 @@ function _mailchimp_campaign_get_entity_import_form($form, &$form_state) {
       'wrapper' => 'content-entity-lookup-wrapper',
     ),
   );
-  $form['entity_import']['entity_type']['#attributes']['class'][] = 'entity-import-entity-type';
+  $form['entity_import']['entity_type']['#attributes']['id'] = 'entity-import-entity-type-' . $element_tag;
 
   $form['entity_import']['entity_id'] = array(
     '#type' => 'textfield',
@@ -608,7 +611,7 @@ function _mailchimp_campaign_get_entity_import_form($form, &$form_state) {
     '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
     '#prefix' => '<div id="content-entity-lookup-wrapper">',
   );
-  $form['entity_import']['entity_id']['#attributes']['class'][] = 'entity-import-entity-id';
+  $form['entity_import']['entity_id']['#attributes']['id'] = 'entity-import-entity-id-' . $element_tag;
 
   $form['entity_import']['entity_view_mode'] = array(
     '#type' => 'select',
@@ -616,17 +619,17 @@ function _mailchimp_campaign_get_entity_import_form($form, &$form_state) {
     '#options' => $entity_view_mode_options,
     '#suffix' => '</div>',
   );
-  $form['entity_import']['entity_view_mode']['#attributes']['class'][] = 'entity-import-entity-view-mode';
+  $form['entity_import']['entity_view_mode']['#attributes']['id'] = 'entity-import-entity-view-mode-' . $element_tag;
 
   $form['entity_import']['entity_import_link'] = array(
     '#type' => 'item',
-    '#markup' => '<a id="add-entity-token" href="javascript:void(0);">Add entity token</a>',
+    '#markup' => '<a id="add-entity-token-' . $element_tag . '" class="add-entity-token" href="javascript:void(0);">Add entity token</a>',
   );
   $form['entity_import']['entity_import_link']['#attributes']['class'][] = 'entity-import-entity-import-link';
 
   $form['entity_import']['entity_import_tag'] = array(
     '#type' => 'item',
-    '#markup' => '<div id="entity-import-tag-field"></div>',
+    '#markup' => '<div id="entity-import-tag-field-' . $element_tag. '"></div>',
   );
   $form['entity_import']['entity_import_tag']['#attributes']['class'][] = 'entity-import-entity-import-tag';
 

--- a/modules/mailchimp_campaign/mailchimp_campaign.module
+++ b/modules/mailchimp_campaign/mailchimp_campaign.module
@@ -385,7 +385,7 @@ function mailchimp_campaign_send_campaign(MailChimpCampaign $campaign) {
     watchdog('mailchimp_campaign', 'MailChimp campaign %name has been sent.',
       array('%name' => $campaign->label())
     );
-    cache_clear_all('mailchimp_campaigns', 'cache_mailchimp');
+    entity_get_controller('mailchimp_campaign')->resetCache(array($campaign->identifier()));
     return TRUE;
   }
   elseif (isset($result['status']) && ($result['status'] == 'error')) {

--- a/modules/mailchimp_campaign/mailchimp_campaign.module
+++ b/modules/mailchimp_campaign/mailchimp_campaign.module
@@ -564,7 +564,7 @@ function mailchimp_campaign_filter_info() {
  *   Translated text to display as a tip.
  */
 function mailchimp_campaign_filter_tips($filter, $format, $long) {
-  $tip = t('Converts content tokens in the format %pattern into the appropriate rendered content and makes all paths absolute.',
+  $tip = t('Converts content tokens in the format %pattern into the appropriate rendered content and makes all paths absolute. Use the "Insert Site Content" widget below to generate tokens.',
     array('%pattern' => '[mailchimp_campaign|entity_type=node|entity_id=1|view_mode=teaser]')
   );
 

--- a/modules/mailchimp_campaign/mailchimp_campaign.module
+++ b/modules/mailchimp_campaign/mailchimp_campaign.module
@@ -138,7 +138,7 @@ function mailchimp_campaign_menu() {
  *   The entity type to limit search to.
  * @param string $string
  *   The string to search entity titles for.
- * 
+ *
  * @return array
  *   Entities with titles matching search string.
  */
@@ -182,7 +182,7 @@ function mailchimp_campaign_page_title(MailChimpCampaign $campaign) {
 
 /**
  * Access callback for campaigns.
- * 
+ *
  * Provides access to features based on whether or not a campaign has been sent.
  *
  * @param MailChimpCampaign $campaign
@@ -568,133 +568,7 @@ function mailchimp_campaign_filter_tips($filter, $format, $long) {
     array('%pattern' => '[mailchimp_campaign|entity_type=node|entity_id=1|view_mode=teaser]')
   );
 
-  $entity_import_form = drupal_get_form('_mailchimp_campaign_get_entity_import_form');
-  $tip .= drupal_render($entity_import_form);
-
   return $tip;
-}
-
-function _mailchimp_campaign_get_entity_import_form($form, &$form_state) {
-  $entity_info = _mailchimp_campaign_get_entities_for_content_import();
-  $entity_options = _mailchimp_campaign_build_entity_option_list($entity_info);
-  reset($entity_options);
-  $entity_type = current(array_keys($entity_options));
-
-  $entity_view_mode_options = _mailchimp_campaign_build_entity_view_mode_option_list($entity_info[$entity_type]);
-
-  $element_tag = uniqid();
-
-  $form['entity_import'] = array(
-    '#id' => 'entity-import',
-    '#type' => 'fieldset',
-    '#title' => t('Site content import'),
-    '#collapsible' => FALSE,
-  );
-
-  $form['entity_import']['entity_type'] = array(
-    '#type' => 'select',
-    '#title' => t('Entity Type'),
-    '#options' => $entity_options,
-    '#default_value' => $entity_type,
-    '#ajax' => array(
-      'callback' => 'mailchimp_campaign_entity_type_callback',
-      'method' => 'replace',
-      'wrapper' => 'content-entity-lookup-wrapper',
-    ),
-  );
-  $form['entity_import']['entity_type']['#attributes']['id'] = 'entity-import-entity-type-' . $element_tag;
-
-  $form['entity_import']['entity_id'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Entity Title'),
-    // Pass entity type as first parameter to entity autocomplete callback.
-    '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
-    '#prefix' => '<div id="content-entity-lookup-wrapper">',
-  );
-  $form['entity_import']['entity_id']['#attributes']['id'] = 'entity-import-entity-id-' . $element_tag;
-
-  $form['entity_import']['entity_view_mode'] = array(
-    '#type' => 'select',
-    '#title' => t('View Mode'),
-    '#options' => $entity_view_mode_options,
-    '#suffix' => '</div>',
-  );
-  $form['entity_import']['entity_view_mode']['#attributes']['id'] = 'entity-import-entity-view-mode-' . $element_tag;
-
-  $form['entity_import']['entity_import_link'] = array(
-    '#type' => 'item',
-    '#markup' => '<a id="add-entity-token-' . $element_tag . '" class="add-entity-token" href="javascript:void(0);">Add entity token</a>',
-  );
-  $form['entity_import']['entity_import_link']['#attributes']['class'][] = 'entity-import-entity-import-link';
-
-  $form['entity_import']['entity_import_tag'] = array(
-    '#type' => 'item',
-    '#markup' => '<div id="entity-import-tag-field-' . $element_tag. '"></div>',
-  );
-  $form['entity_import']['entity_import_tag']['#attributes']['class'][] = 'entity-import-entity-import-tag';
-
-  return $form;
-}
-
-/**
- * Returns an array of entities based on data from entity_get_info().
- *
- * Filters out entities that do not contain a title field, as they cannot
- * be used to import content into templates.
- *
- * @return array
- *   Filtered entities from entity_get_info().
- */
-function _mailchimp_campaign_get_entities_for_content_import() {
-  $entity_info = entity_get_info();
-
-  $filtered_entities = array();
-  foreach ($entity_info as $key => $entity) {
-    if (in_array('title', $entity['schema_fields_sql']['base table'])) {
-      $filtered_entities[$key] = $entity;
-    }
-  }
-
-  return $filtered_entities;
-}
-
-/**
- * Returns an options list of entities based on data from entity_get_info().
- *
- * Filters out entities that do not contain a title field, as they cannot
- * be used to import content into templates.
- *
- * @param array $entity_info
- *   Array of entities as returned by entity_get_info().
- *
- * @return array
- *   Associative array of entity IDs to name.
- */
-function _mailchimp_campaign_build_entity_option_list($entity_info) {
-  $options = array();
-  foreach ($entity_info as $entity_id => $entity_data) {
-    $options[$entity_id] = $entity_data['label'];
-  }
-
-  return $options;
-}
-
-/**
- * Returns an options list of entity view modes.
- *
- * @param array $entity
- *   Array of entity data as returned by entity_get_info().
- *
- * @return array
- *   Associative array of view mode IDs to name.
- */
-function _mailchimp_campaign_build_entity_view_mode_option_list(array $entity) {
-  $options = array();
-  foreach ($entity['view modes'] as $view_mode_id => $view_mode_data) {
-    $options[$view_mode_id] = $view_mode_data['label'];
-  }
-
-  return $options;
 }
 
 /**

--- a/modules/mailchimp_campaign/mailchimp_campaign.module
+++ b/modules/mailchimp_campaign/mailchimp_campaign.module
@@ -573,7 +573,8 @@ function mailchimp_campaign_filter_tips($filter, $format, $long) {
     array('%pattern' => '[mailchimp_campaign|entity_type=node|entity_id=1|view_mode=teaser]')
   );
 
-  $tip .= drupal_render(drupal_get_form('_mailchimp_campaign_get_entity_import_form'));
+  $entity_import_form = drupal_get_form('_mailchimp_campaign_get_entity_import_form');
+  $tip .= drupal_render($entity_import_form);
 
   return $tip;
 }
@@ -585,6 +586,8 @@ function _mailchimp_campaign_get_entity_import_form($form, &$form_state) {
   $entity_type = current(array_keys($entity_options));
 
   $entity_view_mode_options = _mailchimp_campaign_build_entity_view_mode_option_list($entity_info[$entity_type]);
+
+  $element_tag = uniqid();
 
   $form['entity_import'] = array(
     '#id' => 'entity-import',
@@ -604,7 +607,7 @@ function _mailchimp_campaign_get_entity_import_form($form, &$form_state) {
       'wrapper' => 'content-entity-lookup-wrapper',
     ),
   );
-  $form['entity_import']['entity_type']['#attributes']['class'][] = 'entity-import-entity-type';
+  $form['entity_import']['entity_type']['#attributes']['id'] = 'entity-import-entity-type-' . $element_tag;
 
   $form['entity_import']['entity_id'] = array(
     '#type' => 'textfield',
@@ -613,7 +616,7 @@ function _mailchimp_campaign_get_entity_import_form($form, &$form_state) {
     '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
     '#prefix' => '<div id="content-entity-lookup-wrapper">',
   );
-  $form['entity_import']['entity_id']['#attributes']['class'][] = 'entity-import-entity-id';
+  $form['entity_import']['entity_id']['#attributes']['id'] = 'entity-import-entity-id-' . $element_tag;
 
   $form['entity_import']['entity_view_mode'] = array(
     '#type' => 'select',
@@ -621,17 +624,17 @@ function _mailchimp_campaign_get_entity_import_form($form, &$form_state) {
     '#options' => $entity_view_mode_options,
     '#suffix' => '</div>',
   );
-  $form['entity_import']['entity_view_mode']['#attributes']['class'][] = 'entity-import-entity-view-mode';
+  $form['entity_import']['entity_view_mode']['#attributes']['id'] = 'entity-import-entity-view-mode-' . $element_tag;
 
   $form['entity_import']['entity_import_link'] = array(
     '#type' => 'item',
-    '#markup' => '<a id="add-entity-token" href="javascript:void(0);">Add entity token</a>',
+    '#markup' => '<a id="add-entity-token-' . $element_tag . '" class="add-entity-token" href="javascript:void(0);">Add entity token</a>',
   );
   $form['entity_import']['entity_import_link']['#attributes']['class'][] = 'entity-import-entity-import-link';
 
   $form['entity_import']['entity_import_tag'] = array(
     '#type' => 'item',
-    '#markup' => '<div id="entity-import-tag-field"></div>',
+    '#markup' => '<div id="entity-import-tag-field-' . $element_tag. '"></div>',
   );
   $form['entity_import']['entity_import_tag']['#attributes']['class'][] = 'entity-import-entity-import-tag';
 

--- a/modules/mailchimp_campaign/mailchimp_campaign.module
+++ b/modules/mailchimp_campaign/mailchimp_campaign.module
@@ -564,9 +564,134 @@ function mailchimp_campaign_filter_info() {
  *   Translated text to display as a tip.
  */
 function mailchimp_campaign_filter_tips($filter, $format, $long) {
-  return t('Converts macros in the format %pattern into the appropriate rendered content and makes all paths absolute.',
+  $tip = t('Converts content tokens in the format %pattern into the appropriate rendered content and makes all paths absolute.',
     array('%pattern' => '[mailchimp_campaign|entity_type=node|entity_id=1|view_mode=teaser]')
   );
+
+  $tip .= drupal_render(drupal_get_form('_mailchimp_campaign_get_entity_import_form'));
+
+  return $tip;
+}
+
+function _mailchimp_campaign_get_entity_import_form($form, &$form_state) {
+  $entity_info = _mailchimp_campaign_get_entities_for_content_import();
+  $entity_options = _mailchimp_campaign_build_entity_option_list($entity_info);
+  reset($entity_options);
+  $entity_type = current(array_keys($entity_options));
+
+  $entity_view_mode_options = _mailchimp_campaign_build_entity_view_mode_option_list($entity_info[$entity_type]);
+
+  $form['entity_import'] = array(
+    '#id' => 'entity-import',
+    '#type' => 'fieldset',
+    '#title' => t('Site content import'),
+    '#collapsible' => FALSE,
+  );
+
+  $form['entity_import']['entity_type'] = array(
+    '#type' => 'select',
+    '#title' => t('Entity Type'),
+    '#options' => $entity_options,
+    '#default_value' => $entity_type,
+    '#ajax' => array(
+      'callback' => 'mailchimp_campaign_entity_type_callback',
+      'method' => 'replace',
+      'wrapper' => 'content-entity-lookup-wrapper',
+    ),
+  );
+  $form['entity_import']['entity_type']['#attributes']['class'][] = 'entity-import-entity-type';
+
+  $form['entity_import']['entity_id'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Entity Title'),
+    // Pass entity type as first parameter to entity autocomplete callback.
+    '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
+    '#prefix' => '<div id="content-entity-lookup-wrapper">',
+  );
+  $form['entity_import']['entity_id']['#attributes']['class'][] = 'entity-import-entity-id';
+
+  $form['entity_import']['entity_view_mode'] = array(
+    '#type' => 'select',
+    '#title' => t('View Mode'),
+    '#options' => $entity_view_mode_options,
+    '#suffix' => '</div>',
+  );
+  $form['entity_import']['entity_view_mode']['#attributes']['class'][] = 'entity-import-entity-view-mode';
+
+  $form['entity_import']['entity_import_link'] = array(
+    '#type' => 'item',
+    '#markup' => '<a id="add-entity-token" href="javascript:void(0);">Add entity token</a>',
+  );
+  $form['entity_import']['entity_import_link']['#attributes']['class'][] = 'entity-import-entity-import-link';
+
+  $form['entity_import']['entity_import_tag'] = array(
+    '#type' => 'item',
+    '#markup' => '<div id="entity-import-tag-field"></div>',
+  );
+  $form['entity_import']['entity_import_tag']['#attributes']['class'][] = 'entity-import-entity-import-tag';
+
+  return $form;
+}
+
+/**
+ * Returns an array of entities based on data from entity_get_info().
+ *
+ * Filters out entities that do not contain a title field, as they cannot
+ * be used to import content into templates.
+ *
+ * @return array
+ *   Filtered entities from entity_get_info().
+ */
+function _mailchimp_campaign_get_entities_for_content_import() {
+  $entity_info = entity_get_info();
+
+  $filtered_entities = array();
+  foreach ($entity_info as $key => $entity) {
+    if (in_array('title', $entity['schema_fields_sql']['base table'])) {
+      $filtered_entities[$key] = $entity;
+    }
+  }
+
+  return $filtered_entities;
+}
+
+/**
+ * Returns an options list of entities based on data from entity_get_info().
+ *
+ * Filters out entities that do not contain a title field, as they cannot
+ * be used to import content into templates.
+ *
+ * @param array $entity_info
+ *   Array of entities as returned by entity_get_info().
+ *
+ * @return array
+ *   Associative array of entity IDs to name.
+ */
+function _mailchimp_campaign_build_entity_option_list($entity_info) {
+  $options = array();
+  foreach ($entity_info as $entity_id => $entity_data) {
+    $options[$entity_id] = $entity_data['label'];
+  }
+
+  return $options;
+}
+
+/**
+ * Returns an options list of entity view modes.
+ *
+ * @param array $entity
+ *   Array of entity data as returned by entity_get_info().
+ *
+ * @return array
+ *   Associative array of view mode IDs to name.
+ */
+function _mailchimp_campaign_build_entity_view_mode_option_list(array $entity) {
+  $options = array();
+  foreach ($entity['view modes'] as $view_mode_id => $view_mode_data) {
+    $options[$view_mode_id] = $view_mode_data['label'];
+  }
+
+  return $options;
 }
 
 /**

--- a/modules/mailchimp_campaign/mailchimp_campaign.module
+++ b/modules/mailchimp_campaign/mailchimp_campaign.module
@@ -569,9 +569,134 @@ function mailchimp_campaign_filter_info() {
  *   Translated text to display as a tip.
  */
 function mailchimp_campaign_filter_tips($filter, $format, $long) {
-  return t('Converts macros in the format %pattern into the appropriate rendered content and makes all paths absolute.',
+  $tip = t('Converts content tokens in the format %pattern into the appropriate rendered content and makes all paths absolute.',
     array('%pattern' => '[mailchimp_campaign|entity_type=node|entity_id=1|view_mode=teaser]')
   );
+
+  $tip .= drupal_render(drupal_get_form('_mailchimp_campaign_get_entity_import_form'));
+
+  return $tip;
+}
+
+function _mailchimp_campaign_get_entity_import_form($form, &$form_state) {
+  $entity_info = _mailchimp_campaign_get_entities_for_content_import();
+  $entity_options = _mailchimp_campaign_build_entity_option_list($entity_info);
+  reset($entity_options);
+  $entity_type = current(array_keys($entity_options));
+
+  $entity_view_mode_options = _mailchimp_campaign_build_entity_view_mode_option_list($entity_info[$entity_type]);
+
+  $form['entity_import'] = array(
+    '#id' => 'entity-import',
+    '#type' => 'fieldset',
+    '#title' => t('Site content import'),
+    '#collapsible' => FALSE,
+  );
+
+  $form['entity_import']['entity_type'] = array(
+    '#type' => 'select',
+    '#title' => t('Entity Type'),
+    '#options' => $entity_options,
+    '#default_value' => $entity_type,
+    '#ajax' => array(
+      'callback' => 'mailchimp_campaign_entity_type_callback',
+      'method' => 'replace',
+      'wrapper' => 'content-entity-lookup-wrapper',
+    ),
+  );
+  $form['entity_import']['entity_type']['#attributes']['class'][] = 'entity-import-entity-type';
+
+  $form['entity_import']['entity_id'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Entity Title'),
+    // Pass entity type as first parameter to entity autocomplete callback.
+    '#autocomplete_path' => 'admin/config/services/mailchimp/campaigns/entities/' . $entity_type,
+    '#prefix' => '<div id="content-entity-lookup-wrapper">',
+  );
+  $form['entity_import']['entity_id']['#attributes']['class'][] = 'entity-import-entity-id';
+
+  $form['entity_import']['entity_view_mode'] = array(
+    '#type' => 'select',
+    '#title' => t('View Mode'),
+    '#options' => $entity_view_mode_options,
+    '#suffix' => '</div>',
+  );
+  $form['entity_import']['entity_view_mode']['#attributes']['class'][] = 'entity-import-entity-view-mode';
+
+  $form['entity_import']['entity_import_link'] = array(
+    '#type' => 'item',
+    '#markup' => '<a id="add-entity-token" href="javascript:void(0);">Add entity token</a>',
+  );
+  $form['entity_import']['entity_import_link']['#attributes']['class'][] = 'entity-import-entity-import-link';
+
+  $form['entity_import']['entity_import_tag'] = array(
+    '#type' => 'item',
+    '#markup' => '<div id="entity-import-tag-field"></div>',
+  );
+  $form['entity_import']['entity_import_tag']['#attributes']['class'][] = 'entity-import-entity-import-tag';
+
+  return $form;
+}
+
+/**
+ * Returns an array of entities based on data from entity_get_info().
+ *
+ * Filters out entities that do not contain a title field, as they cannot
+ * be used to import content into templates.
+ *
+ * @return array
+ *   Filtered entities from entity_get_info().
+ */
+function _mailchimp_campaign_get_entities_for_content_import() {
+  $entity_info = entity_get_info();
+
+  $filtered_entities = array();
+  foreach ($entity_info as $key => $entity) {
+    if (in_array('title', $entity['schema_fields_sql']['base table'])) {
+      $filtered_entities[$key] = $entity;
+    }
+  }
+
+  return $filtered_entities;
+}
+
+/**
+ * Returns an options list of entities based on data from entity_get_info().
+ *
+ * Filters out entities that do not contain a title field, as they cannot
+ * be used to import content into templates.
+ *
+ * @param array $entity_info
+ *   Array of entities as returned by entity_get_info().
+ *
+ * @return array
+ *   Associative array of entity IDs to name.
+ */
+function _mailchimp_campaign_build_entity_option_list($entity_info) {
+  $options = array();
+  foreach ($entity_info as $entity_id => $entity_data) {
+    $options[$entity_id] = $entity_data['label'];
+  }
+
+  return $options;
+}
+
+/**
+ * Returns an options list of entity view modes.
+ *
+ * @param array $entity
+ *   Array of entity data as returned by entity_get_info().
+ *
+ * @return array
+ *   Associative array of view mode IDs to name.
+ */
+function _mailchimp_campaign_build_entity_view_mode_option_list(array $entity) {
+  $options = array();
+  foreach ($entity['view modes'] as $view_mode_id => $view_mode_data) {
+    $options[$view_mode_id] = $view_mode_data['label'];
+  }
+
+  return $options;
 }
 
 /**

--- a/modules/mailchimp_campaign/tests/mailchimp_campaigns.test
+++ b/modules/mailchimp_campaign/tests/mailchimp_campaigns.test
@@ -71,4 +71,5 @@ class MailchimpCampaignsTestCase extends DrupalWebTestCase {
 
     $this->assertEqual($campaign['id'], $campaign_id);
   }
+
 }


### PR DESCRIPTION
- Moved content import form into MailChimp Campaign input filter help section.
- Moved merge vars into individual content blocks. Didn't move into input filter help section because merge vars are not limited to the input filter.
- Fixed bug causing campaign cache "data" property to be cached recursively. Resulted in $cache->data->data, etc.
