### PR TITLE
Issue #2446683 by sardara, angel.h: "Signup form" entity form translatio...

### DIFF
--- a/modules/mailchimp_signup/includes/mailchimp_signup.admin.inc
+++ b/modules/mailchimp_signup/includes/mailchimp_signup.admin.inc
@@ -37,7 +37,7 @@ function mailchimp_signup_form($form, &$form_state, MailchimpSignup $signup) {
   );
   $form['description'] = array(
     '#type' => 'textarea',
-    '#title' => 'Description',
+    '#title' => t('Description'),
     '#default_value' => isset($signup->settings['description']) ? $signup->settings['description'] : '',
     '#rows' => 2,
     '#maxlength' => 500,
@@ -50,7 +50,7 @@ function mailchimp_signup_form($form, &$form_state, MailchimpSignup $signup) {
   );
   $form['mode'] = array(
     '#type' => 'checkboxes',
-    '#title' => 'Display Mode',
+    '#title' => t('Display Mode'),
     '#required' => TRUE,
     '#options' => array(
       MAILCHIMP_SIGNUP_BLOCK => 'Block',
@@ -61,7 +61,7 @@ function mailchimp_signup_form($form, &$form_state, MailchimpSignup $signup) {
 
   $form['settings'] = array(
     '#type' => 'fieldset',
-    '#title' => 'Settings',
+    '#title' => t('Settings'),
     '#tree' => TRUE,
     '#collapsible' => TRUE,
     '#collapsed' => FALSE,
@@ -69,7 +69,7 @@ function mailchimp_signup_form($form, &$form_state, MailchimpSignup $signup) {
 
   $form['settings']['path'] = array(
     '#type' => 'textfield',
-    '#title' => 'Page URL',
+    '#title' => t('Page URL'),
     '#description' => t('Path to the signup page. ie "newsletter/signup".'),
     '#default_value' => isset($signup->settings['path']) ? $signup->settings['path'] : NULL,
     '#states' => array(
@@ -85,22 +85,22 @@ function mailchimp_signup_form($form, &$form_state, MailchimpSignup $signup) {
 
   $form['settings']['submit_button'] = array(
     '#type' => 'textfield',
-    '#title' => 'Submit Button Label',
+    '#title' => t('Submit Button Label'),
     '#required' => 'TRUE',
-    '#default_value' => isset($signup->settings['submit_button']) ? $signup->settings['submit_button'] : 'Submit',
+    '#default_value' => isset($signup->settings['submit_button']) ? $signup->settings['submit_button'] : t('Submit'),
   );
 
   $form['settings']['confirmation_message'] = array(
     '#type' => 'textfield',
-    '#title' => 'Confirmation Message',
-    '#description' => 'This message will appear after a successful submission of this form. Leave blank for no message, but make sure you configure a destination in that case unless you really want to confuse your site visitors.',
-    '#default_value' => isset($signup->settings['confirmation_message']) ? $signup->settings['confirmation_message'] : 'You have been successfully subscribed.',
+    '#title' => t('Confirmation Message'),
+    '#description' => t('This message will appear after a successful submission of this form. Leave blank for no message, but make sure you configure a destination in that case unless you really want to confuse your site visitors.'),
+    '#default_value' => isset($signup->settings['confirmation_message']) ? $signup->settings['confirmation_message'] : t('You have been successfully subscribed.'),
   );
 
   $form['settings']['destination'] = array(
     '#type' => 'textfield',
-    '#title' => 'Form destination page',
-    '#description' => 'Leave blank to stay on the form page.',
+    '#title' => t('Form destination page'),
+    '#description' => t('Leave blank to stay on the form page.'),
     '#default_value' => isset($signup->settings['destination']) ? $signup->settings['destination'] : NULL,
   );
 


### PR DESCRIPTION
Tested with Spanish, and it works where translations are available (for example, "Description"). Adding more translations for more languages would be nice as well.
