### PR TITLE
Drush iq existing subscriber data overwritten 1035906 1

### DIFF
--- a/modules/mailchimp_signup/includes/mailchimp_signup.admin.inc
+++ b/modules/mailchimp_signup/includes/mailchimp_signup.admin.inc
@@ -273,7 +273,7 @@ function mailchimp_signup_form_submit($form, &$form_state) {
   $signup->settings['doublein'] = $form_state['values']['doublein'];
   $signup->settings['send_welcome'] = $form_state['values']['send_welcome'];
   $signup->settings['include_interest_groups'] = $form_state['values']['include_interest_groups'];
-  $signup->settings['preserve_interest_groups'] = $form_state['values']['preserve_interest_groups'];
+  $signup->settings['replace_interests'] = $form_state['values']['replace_interests'];
   if ($signup->save()) {
     if (isset($form_state['values']['settings']['path'])) {
       if (!isset($prior_settings['path']) || $prior_settings['path'] != $signup->settings['path'] || !($signup->mode & MAILCHIMP_SIGNUP_PAGE)) {

--- a/modules/mailchimp_signup/includes/mailchimp_signup.admin.inc
+++ b/modules/mailchimp_signup/includes/mailchimp_signup.admin.inc
@@ -97,6 +97,13 @@ function mailchimp_signup_form($form, &$form_state, MailchimpSignup $signup) {
     '#default_value' => isset($signup->settings['confirmation_message']) ? $signup->settings['confirmation_message'] : t('You have been successfully subscribed.'),
   );
 
+  $form['settings']['update_message'] = array(
+    '#type' => 'textfield',
+    '#title' => 'Update Message',
+    '#description' => 'This message will appear after a successful submission of this form and if the email used is already subscribing. Leave blank for no message, but make sure you configure a destination in that case unless you really want to confuse your site visitors.',
+    '#default_value' => isset($signup->settings['update_message']) ? $signup->settings['update_message'] : 'Your subscription has been updated.',
+  );
+
   $form['settings']['destination'] = array(
     '#type' => 'textfield',
     '#title' => t('Form destination page'),
@@ -200,6 +207,13 @@ function mailchimp_signup_form($form, &$form_state, MailchimpSignup $signup) {
     '#description' => t('If set, subscribers will be able to select applicable interest groups on the signup form.'),
   );
 
+  $form['subscription_settings']['preserve_interest_groups'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Preserve interest groups on resubscription.'),
+    '#default_value' => isset($signup->settings['preserve_interest_groups']) ? $signup->settings['preserve_interest_groups'] : TRUE,
+    '#description' => t('If set, subscribers interest groups will be preserved when they are already subscribing.'),
+  );
+
   $form['save'] = array(
     '#type' => 'submit',
     '#value' => t('Save'),
@@ -259,6 +273,7 @@ function mailchimp_signup_form_submit($form, &$form_state) {
   $signup->settings['doublein'] = $form_state['values']['doublein'];
   $signup->settings['send_welcome'] = $form_state['values']['send_welcome'];
   $signup->settings['include_interest_groups'] = $form_state['values']['include_interest_groups'];
+  $signup->settings['preserve_interest_groups'] = $form_state['values']['preserve_interest_groups'];
   if ($signup->save()) {
     if (isset($form_state['values']['settings']['path'])) {
       if (!isset($prior_settings['path']) || $prior_settings['path'] != $signup->settings['path'] || !($signup->mode & MAILCHIMP_SIGNUP_PAGE)) {

--- a/modules/mailchimp_signup/includes/mailchimp_signup.admin.inc
+++ b/modules/mailchimp_signup/includes/mailchimp_signup.admin.inc
@@ -99,8 +99,8 @@ function mailchimp_signup_form($form, &$form_state, MailchimpSignup $signup) {
 
   $form['settings']['update_message'] = array(
     '#type' => 'textfield',
-    '#title' => 'Update Message',
-    '#description' => 'This message will appear after a successful submission of this form and if the email used is already subscribing. Leave blank for no message, but make sure you configure a destination in that case unless you really want to confuse your site visitors.',
+    '#title' => t('Update Message'),
+    '#description' => t('This message will appear after a successful submission of this form and if the email used is already subscribing. Leave blank for no message, but make sure you configure a destination in that case unless you really want to confuse your site visitors.'),
     '#default_value' => isset($signup->settings['update_message']) ? $signup->settings['update_message'] : 'Your subscription has been updated.',
   );
 
@@ -207,11 +207,11 @@ function mailchimp_signup_form($form, &$form_state, MailchimpSignup $signup) {
     '#description' => t('If set, subscribers will be able to select applicable interest groups on the signup form.'),
   );
 
-  $form['subscription_settings']['preserve_interest_groups'] = array(
+  $form['subscription_settings']['replace_interests'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Preserve interest groups on resubscription.'),
-    '#default_value' => isset($signup->settings['preserve_interest_groups']) ? $signup->settings['preserve_interest_groups'] : TRUE,
-    '#description' => t('If set, subscribers interest groups will be preserved when they are already subscribing.'),
+    '#title' => t('Replace interest groups on resubscription.'),
+    '#default_value' => isset($signup->settings['replace_interests']) ? $signup->settings['replace_interests'] : TRUE,
+    '#description' => t('If set, existing subscriber interest groups will be replaced when they re-subscribe.'),
   );
 
   $form['save'] = array(

--- a/modules/mailchimp_signup/mailchimp_signup.module
+++ b/modules/mailchimp_signup/mailchimp_signup.module
@@ -365,11 +365,13 @@ function mailchimp_signup_subscribe_form_submit($form, &$form_state) {
   // Loop through the selected lists and try to subscribe:
   foreach ($subscribe_lists as $list_choices) {
     $list_id = $list_choices['subscribe'];
+    // Load possible existing member.
+    $member = mailchimp_get_memberinfo($list_id, $email);
     $mergevars = $merge_values;
     if (isset($list_choices['interest_groups'])) {
       $mergevars['GROUPINGS'] = mailchimp_reformat_groupings($list_choices['interest_groups']);
     }
-    $result = mailchimp_subscribe($list_id, $email, $mergevars, $signup->settings['doublein'], $signup->settings['send_welcome']);
+    $result = mailchimp_subscribe($list_id, $email, $mergevars, $signup->settings['doublein'], $signup->settings['send_welcome'], 'html', TRUE, !$signup->settings['preserve_interest_groups']);
     // Let other modules act on the results in hook_form_alter.
     $form_state['mailchimp_results'] = $result;
     if (empty($result)) {
@@ -381,8 +383,11 @@ function mailchimp_signup_subscribe_form_submit($form, &$form_state) {
       $successes[] = $list_details[$list_id]['name'];
     }
   }
-  if (count($successes) && isset($signup->settings['confirmation_message']) && strlen($signup->settings['confirmation_message'])) {
+  if (count($successes) && isset($signup->settings['confirmation_message']) && strlen($signup->settings['confirmation_message']) && empty($member)) {
     drupal_set_message(check_plain($signup->settings['confirmation_message']), 'status');
+  }
+  if (count($successes) && isset($signup->settings['update_message']) && strlen($signup->settings['update_message']) && !empty($member)) {
+    drupal_set_message($signup->settings['update_message'], 'status');
   }
   if (!empty($signup->settings['destination'])) {
     $form_state['redirect'] = $signup->settings['destination'];

--- a/modules/mailchimp_signup/mailchimp_signup.module
+++ b/modules/mailchimp_signup/mailchimp_signup.module
@@ -258,7 +258,7 @@ function mailchimp_signup_subscribe_form($form, &$form_state, $signup, $type) {
   $lists_count = (!empty($lists)) ? count($lists) : 0;
 
   if (empty($lists)) {
-    drupal_set_message('The subscription service is currently unavailable. Please try again later.', 'warning');
+    drupal_set_message(t('The subscription service is currently unavailable. Please try again later.'), 'warning');
   }
 
   $list = array();
@@ -384,10 +384,10 @@ function mailchimp_signup_subscribe_form_submit($form, &$form_state) {
     }
   }
   if (count($successes) && isset($signup->settings['confirmation_message']) && strlen($signup->settings['confirmation_message']) && empty($member)) {
-    drupal_set_message(check_plain($signup->settings['confirmation_message']), 'status');
+    drupal_set_message(t(check_plain($signup->settings['confirmation_message'])), 'status');
   }
   if (count($successes) && isset($signup->settings['update_message']) && strlen($signup->settings['update_message']) && !empty($member)) {
-    drupal_set_message($signup->settings['update_message'], 'status');
+    drupal_set_message(t(check_plain($signup->settings['update_message'])), 'status');
   }
   if (!empty($signup->settings['destination'])) {
     $form_state['redirect'] = $signup->settings['destination'];

--- a/modules/mailchimp_signup/mailchimp_signup.module
+++ b/modules/mailchimp_signup/mailchimp_signup.module
@@ -371,7 +371,8 @@ function mailchimp_signup_subscribe_form_submit($form, &$form_state) {
     if (isset($list_choices['interest_groups'])) {
       $mergevars['GROUPINGS'] = mailchimp_reformat_groupings($list_choices['interest_groups']);
     }
-    $result = mailchimp_subscribe($list_id, $email, $mergevars, $signup->settings['doublein'], $signup->settings['send_welcome'], 'html', TRUE, !$signup->settings['preserve_interest_groups']);
+
+    $result = mailchimp_subscribe($list_id, $email, $mergevars, $signup->settings['doublein'], $signup->settings['send_welcome'], 'html', TRUE, $signup->settings['replace_interests']);
     // Let other modules act on the results in hook_form_alter.
     $form_state['mailchimp_results'] = $result;
     if (empty($result)) {


### PR DESCRIPTION
Fixes two areas where subscriber data was being over-written.
Fix1. If an anonymous user signed up for a list with an existing list member's address, the existing user lost subscriptions to other lists. This is fixed by the code below handling a check for a pre-existing $member and setting an update_message.

Fix2. The default was to replace interest groups when user info was updated and there was nothing in the UI to change this. This is handled by the code below that handles replace_interests.

Also, there is some translation and check_plain.

I think this looks good and I tested that an anonymous user signup didn't overwrite existing list subscriptions. I also tested that updating information didn't remove existing Groups on MailChimp.

I'm assigning for review in case you get time, but otherwise I will push to d.o this week.
