### PR TITLE
Multiple key support

### DIFF
--- a/includes/mailchimp.admin.inc
+++ b/includes/mailchimp.admin.inc
@@ -82,7 +82,7 @@ function mailchimp_account_overview_page() {
   $api_key_form = drupal_get_form('mailchimp_account_retrieval_form');
   $output .= drupal_render($api_key_form);
   if (isset($_REQUEST['mailchimp_api_key'])) {
-    $account = mailchimp_api_account(NULL, $_REQUEST['mailchimp_api_key']);
+    $account = mailchimp_api_account(NULL, check_plain($_REQUEST['mailchimp_api_key']));
   }
   else {
     $output .= '<h3>Default account</h3>';
@@ -101,16 +101,15 @@ function mailchimp_account_overview_page() {
 function mailchimp_account_retrieval_form($form, &$form_state) {
   $form = array();
   $api_key = (isset($_REQUEST['mailchimp_api_key']))
-    ? $_REQUEST['mailchimp_api_key']
+    ? check_plain($_REQUEST['mailchimp_api_key'])
     : variable_get('mailchimp_api_key', '');
   $form['mailchimp_api_key'] = array(
     '#type' => 'textfield',
-    '#title' => t('MailChimp API Key'),
-    '#required' => TRUE,
+    '#title' => t('MailChimp API Key to check'),
     '#default_value' => $api_key,
-    '#description' => t('The API key for your MailChimp account. Get or generate a valid API key at your !apilink.', array('!apilink' => l(t('MailChimp API Dashboard'), 'http://admin.mailchimp.com/account/api'))),
+    '#description' => t('The API key for which you want to retrieve account info from the MailChimp API. Get or generate a valid API key at your !apilink.', array('!apilink' => l(t('MailChimp API Dashboard'), 'http://admin.mailchimp.com/account/api'))),
   );
-  $form['#action'] = $_SERVER['REQUEST_URI'];
+  $form['#action'] = check_plain($_SERVER['REQUEST_URI']);
   $form['#method'] = 'post';
   $form['submit'] = array(
     '#type' => 'submit',

--- a/includes/mailchimp.admin.inc
+++ b/includes/mailchimp.admin.inc
@@ -68,3 +68,57 @@ function mailchimp_clear_list_cache_form_submit($form, &$form_state) {
   mailchimp_get_lists(array(), TRUE);
   drupal_set_message(t('MailChimp List cache cleared.'));
 }
+
+/**
+ * Menu callback to access mailchimp account info
+ * This allows developers to easily figure out
+ * the account_id associated with a given key,
+ * enabling support for multiple api keys.
+ * @see hook_mailchimp_api_key().
+ */
+function mailchimp_account_overview_page() {
+  $accounts = array();
+  $output = '<h2>Mailchimp API Account Info</h2>';
+  $api_key_form = drupal_get_form('mailchimp_account_retrieval_form');
+  $output .= drupal_render($api_key_form);
+  if (isset($_REQUEST['mailchimp_api_key'])) {
+    $account = mailchimp_api_account(NULL, $_REQUEST['mailchimp_api_key']);
+  }
+  else {
+    $output .= '<h3>Default account</h3>';
+    $account = mailchimp_api_account();
+  }
+  unset($account->_links);
+  $output .= '<pre>'.json_encode($account, JSON_PRETTY_PRINT).'</pre>';
+  return $output;
+}
+
+/**
+ * MailChimp account retrieval form.
+ * Outputs a textfield for an api_key
+ * to retrieve information about a MailChimp account.
+ */
+function mailchimp_account_retrieval_form($form, &$form_state) {
+  $form = array();
+  $api_key = (isset($_REQUEST['mailchimp_api_key']))
+    ? $_REQUEST['mailchimp_api_key']
+    : variable_get('mailchimp_api_key', '');
+  $form['mailchimp_api_key'] = array(
+    '#type' => 'textfield',
+    '#title' => t('MailChimp API Key'),
+    '#required' => TRUE,
+    '#default_value' => $api_key,
+    '#description' => t('The API key for your MailChimp account. Get or generate a valid API key at your !apilink.', array('!apilink' => l(t('MailChimp API Dashboard'), 'http://admin.mailchimp.com/account/api'))),
+  );
+  $form['#action'] = $_SERVER['REQUEST_URI'];
+  $form['#method'] = 'post';
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Get account info'),
+  );
+  return $form;
+}
+
+function mailchimp_account_retrieval_form_submit($form, &$form_state) {
+  $form_state['rebuild'] = TRUE;
+}

--- a/includes/mailchimp.admin.inc
+++ b/includes/mailchimp.admin.inc
@@ -79,8 +79,6 @@ function mailchimp_clear_list_cache_form_submit($form, &$form_state) {
  * @see hook_mailchimp_api_key()
  */
 function mailchimp_account_overview_page() {
-  $accounts = array();
-  $output = '<h2>Mailchimp API Account Info</h2>';
   $api_key_form = drupal_get_form('mailchimp_account_retrieval_form');
   $output .= drupal_render($api_key_form);
   if (isset($_REQUEST['mailchimp_api_key'])) {

--- a/includes/mailchimp.admin.inc
+++ b/includes/mailchimp.admin.inc
@@ -108,7 +108,7 @@ function mailchimp_account_retrieval_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('MailChimp API Key to check'),
     '#default_value' => $api_key,
-    '#description' => t('The default API key for your MailChimp account. Get or generate a valid API key at your !apilink.', array('!apilink' => l(t('MailChimp API Dashboard'), 'http://admin.mailchimp.com/account/api'))),
+    '#description' => t('The API key to check. Get or generate a valid API key at your !apilink.', array('!apilink' => l(t('MailChimp API Dashboard'), 'http://admin.mailchimp.com/account/api'))),
   );
   $form['#action'] = check_plain($_SERVER['REQUEST_URI']);
   $form['#method'] = 'post';

--- a/includes/mailchimp.admin.inc
+++ b/includes/mailchimp.admin.inc
@@ -70,11 +70,13 @@ function mailchimp_clear_list_cache_form_submit($form, &$form_state) {
 }
 
 /**
- * Menu callback to access mailchimp account info
+ * Menu callback to access mailchimp account info.
+ *
  * This allows developers to easily figure out
  * the account_id associated with a given key,
  * enabling support for multiple api keys.
- * @see hook_mailchimp_api_key().
+ *
+ * @see hook_mailchimp_api_key()
  */
 function mailchimp_account_overview_page() {
   $accounts = array();
@@ -89,12 +91,13 @@ function mailchimp_account_overview_page() {
     $account = mailchimp_api_account();
   }
   unset($account->_links);
-  $output .= '<pre>'.json_encode($account, JSON_PRETTY_PRINT).'</pre>';
+  $output .= '<pre>' . json_encode($account, JSON_PRETTY_PRINT) . '</pre>';
   return $output;
 }
 
 /**
  * MailChimp account retrieval form.
+ *
  * Outputs a textfield for an api_key
  * to retrieve information about a MailChimp account.
  */
@@ -107,7 +110,7 @@ function mailchimp_account_retrieval_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('MailChimp API Key to check'),
     '#default_value' => $api_key,
-    '#description' => t('The API key for which you want to retrieve account info from the MailChimp API. Get or generate a valid API key at your !apilink.', array('!apilink' => l(t('MailChimp API Dashboard'), 'http://admin.mailchimp.com/account/api'))),
+    '#description' => t('The default API key for your MailChimp account. Get or generate a valid API key at your !apilink.', array('!apilink' => l(t('MailChimp API Dashboard'), 'http://admin.mailchimp.com/account/api'))),
   );
   $form['#action'] = check_plain($_SERVER['REQUEST_URI']);
   $form['#method'] = 'post';
@@ -118,6 +121,9 @@ function mailchimp_account_retrieval_form($form, &$form_state) {
   return $form;
 }
 
+/**
+ * Form submit handler to enable the POST request processing.
+ */
 function mailchimp_account_retrieval_form_submit($form, &$form_state) {
   $form_state['rebuild'] = TRUE;
 }

--- a/mailchimp.api.php
+++ b/mailchimp.api.php
@@ -58,32 +58,35 @@ function hook_mailchimp_unsubscribe_user($list_id, $email) {
 }
 
 /**
- * Register additional api keys to enable multiple accounts
+ * Register additional api keys to enable multiple accounts.
+ *
  * @return array
- *   array_key is the mailchimp account_id
- *   array_value is the api key
+ *   array_key is the mailchimp account_id.
+ *   array_value is the api key.
  */
 function hook_mailchimp_api_key() {
   return array('xxxxxxxxxxx' => 'api_key_here')
 }
 
 /**
- * Alter the key for a given api request
- * @param  string &$api_key
- *   The MailChimp API key
- * @param  array  $context
- *   The MailChimp API classname of the API object
+ * Alter the key for a given api request.
+ *
+ * @param string &$api_key
+ *   The MailChimp API key.
+ * @param array $context
+ *   The MailChimp API classname of the API object.
  */
 function hook_mailchimp_api_key_alter(&$api_key, $context) {
 
 }
 
 /**
- * Perform an action after an api object has been created
- * @param  object $account
- *   The MailChimp API account object
- * @param  [type] $context
- *   The MailChimp API classname of the API object
+ * Perform an action after an api object has been created.
+ *
+ * @param object $account
+ *   The MailChimp API account object.
+ * @param array $context
+ *   The MailChimp API classname of the API object.
  */
 function hook_mailchimp_api_accessed($account, $context) {
 

--- a/mailchimp.api.php
+++ b/mailchimp.api.php
@@ -56,3 +56,35 @@ function hook_mailchimp_subscribe_user($list_id, $email, $merge_vars) {
 function hook_mailchimp_unsubscribe_user($list_id, $email) {
 
 }
+
+/**
+ * Register additional api keys to enable multiple accounts
+ * @return array
+ *   array_key is the mailchimp account_id
+ *   array_value is the api key
+ */
+function hook_mailchimp_api_key() {
+  return array('xxxxxxxxxxx' => 'api_key_here')
+}
+
+/**
+ * Alter the key for a given api request
+ * @param  string &$api_key
+ *   The MailChimp API key
+ * @param  array  $context
+ *   The MailChimp API classname of the API object
+ */
+function hook_mailchimp_api_key_alter(&$api_key, $context) {
+
+}
+
+/**
+ * Perform an action after an api object has been created
+ * @param  object $account
+ *   The MailChimp API account object
+ * @param  [type] $context
+ *   The MailChimp API classname of the API object
+ */
+function hook_mailchimp_api_accessed($account, $context) {
+
+}

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -159,7 +159,7 @@ function mailchimp_get_api_object($classname = 'Mailchimp', $api_key = NULL) {
 
   if (!$api_key) {
     $api_key = (isset($_REQUEST['mc_aid']))
-      ? mailchimp_get_api_key_for_account($_REQUEST['mc_aid'])
+      ? mailchimp_get_api_key_for_account(check_plain($_REQUEST['mc_aid']))
       : variable_get('mailchimp_api_key', '');
   }
   $context = array(
@@ -277,6 +277,7 @@ function mailchimp_account_select_form($form, &$form_state) {
     $form['mc_aid'] = array(
        '#type' => 'select',
        '#options' => $options,
+       '#default_value' => 'default',
     );
     $form['#action'] = $_SERVER['REQUEST_URI'];
     $form['#method'] = 'get';

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -78,6 +78,14 @@ function mailchimp_menu() {
     'access arguments' => array(2),
     'type' => MENU_CALLBACK,
   );
+  $items['admin/config/services/mailchimp/account-info'] = array(
+    'title' => 'MailChimp account info',
+    'page callback' => 'mailchimp_account_overview_page',
+    'access callback' => 'mailchimp_apikey_ready_access',
+    'access arguments' => array('administer mailchimp'),
+    'file' => 'includes/mailchimp.admin.inc',
+    'type' => MENU_CALLBACK,
+  );
 
   return $items;
 }
@@ -110,10 +118,13 @@ function mailchimp_apikey_ready_access($permission) {
  * @param string $classname
  *   The MailChimp library class to instantiate.
  *
+ * @param string $api_key
+ *   The MailChimp api key to use if not the default
+ *
  * @return Mailchimp
  *   Instance of the MailChimp library class. Can be overridden by $classname.
  */
-function mailchimp_get_api_object($classname = 'Mailchimp') {
+function mailchimp_get_api_object($classname = 'Mailchimp', $api_key = NULL) {
   // Set correct library class namespace depending on test mode.
   if (variable_get('mailchimp_test_mode', FALSE)) {
     $classname = '\Mailchimp\Tests\\' . $classname;
@@ -123,7 +134,7 @@ function mailchimp_get_api_object($classname = 'Mailchimp') {
   }
 
   $mailchimp = &drupal_static(__FUNCTION__);
-  if (isset($mailchimp) && $mailchimp instanceof $classname) {
+  if (!$api_key && isset($mailchimp) && $mailchimp instanceof $classname) {
     return $mailchimp;
   }
   if (module_exists('libraries')) {
@@ -146,7 +157,16 @@ function mailchimp_get_api_object($classname = 'Mailchimp') {
     return NULL;
   }
 
-  $api_key = variable_get('mailchimp_api_key', '');
+  if (!$api_key) {
+    $api_key = (isset($_REQUEST['mc_aid']))
+      ? mailchimp_get_api_key_for_account($_REQUEST['mc_aid'])
+      : variable_get('mailchimp_api_key', '');
+  }
+  $context = array(
+    'api_class' => $classname,
+  );
+  drupal_alter('mailchimp_api_key', $api_key, $context);
+
   if (!strlen($api_key)) {
     watchdog('mailchimp', t('MailChimp Error: API Key cannot be blank.'), array(), WATCHDOG_ERROR);
     return NULL;
@@ -155,8 +175,128 @@ function mailchimp_get_api_object($classname = 'Mailchimp') {
   $timeout = 60;
 
   $mailchimp = new $classname($api_key, 'apikey', $timeout);
-
+  $account = mailchimp_api_account($mailchimp);
+  module_invoke_all('mailchimp_api_accessed', $account, $context);
   return $mailchimp;
+}
+
+/**
+ * Implements hook_mailchimp_api_key().
+ *
+ * @return array
+ *   Since we don't know the default account_id, we use 'default'
+ */
+function mailchimp_mailchimp_api_key() {
+  return array('default' => variable_get('mailchimp_api_key', ''));
+}
+
+/**
+ * Invokes hook_mailchimp_api_key so modules can declare keys
+ *
+ * @return array
+ *   The array_keys are the account id and the array_values are the api keys
+ *   @see hook_mailchimp_api_key();
+ */
+function mailchimp_api_keys() {
+  $api_keys = module_invoke_all('mailchimp_api_key');
+  return $api_keys;
+}
+
+/**
+ * Creates an array of working api accounts in the system
+ *
+ * @return array
+ *   The array_key is the account_id, the array_value is the account object.
+ */
+function mailchimp_api_accounts() {
+  $api_accounts = array();
+  $api_keys = mailchimp_api_keys();
+  foreach ($api_keys as $account_id => $api_key) {
+    $account = mailchimp_api_account(NULL, $api_key);
+    $api_accounts[$account_id] = $account;
+  }
+  return $api_accounts;
+}
+
+/**
+ * Wrapper around Mailchimp->getAccount().
+ *
+ * @param  object $api
+ *   The api object to use, if already instantiated
+ *
+ * @param  string $api_key
+ *   The api key to use to instantiate the MailChimp API object
+ *
+ * @return Object
+ *   The MailChimp account object.
+ */
+function mailchimp_api_account($api = NULL, $api_key = NULL) {
+  if (!$api) {
+    $api = mailchimp_get_api_object('Mailchimp', $api_key);
+  }
+  return $api->getAccount();
+}
+
+/**
+ * Returns the api key based on a given account id.
+ *
+ * @param  string $account_id
+ *   The MailChimp account_id
+ *   @see mailchimp_account_overview_page().
+ *
+ * @return string
+ *   The api key registered via hook_mailchimp_api_key().
+ *   @see hook_mailchimp_api_key().
+ */
+function mailchimp_get_api_key_for_account($account_id) {
+  $api_keys = mailchimp_api_keys();
+  if (isset($api_keys[$account_id])) {
+    return $api_keys[$account_id];
+  }
+  watchdog('mailchimp', t('MailChimp Error: API Key not set for account @account_id.'), array('@account_id' => $account_id), WATCHDOG_ERROR);
+  return NULL;
+}
+
+/**
+ * MailChimp account select form.
+ * Enables switching between multiple keys.
+ * @see hook_mailchimp_api_key().
+ */
+function mailchimp_account_select_form($form, &$form_state) {
+  $form = array();
+  $account = mailchimp_api_account();
+  $form['heading'] = array(
+    '#markup' => '<h2>' . $account->account_name . '</h2>',
+  );
+  $accounts = mailchimp_api_accounts();
+  if (count($accounts) > 1) {
+    $options = array();
+    foreach ($accounts as $account_id => $account) {
+      $options[$account_id] = $account->account_name;
+    }
+    $form['mc_aid'] = array(
+       '#type' => 'select',
+       '#options' => $options,
+    );
+    $form['#action'] = $_SERVER['REQUEST_URI'];
+    $form['#method'] = 'get';
+    $form['#pre_render'][] = 'mailchimp_account_select_form_modify';
+    $form['submit'] = array(
+      '#type' => 'submit',
+      '#value' => t('Select'),
+    );
+  }
+  return $form;
+}
+
+/**
+ * Removes unnecessary url variables
+ */
+function mailchimp_account_select_form_modify($form){
+  unset($form['form_token']);
+  unset($form['form_build_id']);
+  unset($form['form_id']);
+  return $form;
 }
 
 /**
@@ -185,7 +325,10 @@ function mailchimp_get_list($list_id) {
  *   An array of list arrays.
  */
 function mailchimp_get_lists($list_ids = array(), $reset = FALSE) {
-  $cache = $reset ? NULL : cache_get('lists', 'cache_mailchimp');
+  if ($account = mailchimp_api_account()) {
+    $account_id = $account->account_id;
+    $cache = $reset ? NULL : cache_get('lists-' . $account_id, 'cache_mailchimp');
+  }
   $lists = array();
   // Return cached lists:
   if ($cache) {
@@ -229,7 +372,8 @@ function mailchimp_get_lists($list_ids = array(), $reset = FALSE) {
         }
       }
       uasort($lists, '_mailchimp_list_cmp');
-      cache_set('lists', $lists, 'cache_mailchimp', CACHE_TEMPORARY);
+      $account = mailchimp_api_account($mc_lists);
+      cache_set('lists-' . $account->account_id , $lists, 'cache_mailchimp', CACHE_TEMPORARY);
     }
     catch (Exception $e) {
       watchdog('mailchimp', 'An error occurred requesting list information from MailChimp. "%message"', array(
@@ -1230,6 +1374,13 @@ function mailchimp_cache_clear_list_activity($list_id) {
  */
 function mailchimp_cache_clear_campaign($campaign_id) {
   cache_clear_all('mailchimp_campaign_' . $campaign_id, 'cache_mailchimp');
+}
+
+/**
+ * Clear all mailchimp caches.
+ */
+function mailchimp_cache_clear_all() {
+  cache_clear_all('*', 'cache_mailchimp', TRUE);
 }
 
 /**

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -79,7 +79,7 @@ function mailchimp_menu() {
     'type' => MENU_CALLBACK,
   );
   $items['admin/config/services/mailchimp/account-info'] = array(
-    'title' => 'MailChimp account info',
+    'title' => 'MailChimp API Account Info',
     'page callback' => 'mailchimp_account_overview_page',
     'access callback' => 'mailchimp_apikey_ready_access',
     'access arguments' => array('administer mailchimp'),
@@ -277,7 +277,7 @@ function mailchimp_account_select_form($form, &$form_state) {
     $form['mc_aid'] = array(
       '#type' => 'select',
       '#options' => $options,
-      '#default_value' => 'default',
+      '#default_value' => (isset($_REQUEST['mc_aid'])) ? $_REQUEST['mc_aid'] : 'default',
     );
     $form['#action'] = $_SERVER['REQUEST_URI'];
     $form['#method'] = 'get';

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -187,6 +187,17 @@ function mailchimp_mailchimp_api_key() {
 }
 
 /**
+ * Implements hook_mailchimp_api_key_alter().
+ *
+ * @see mailchimp_account_select_form().
+ */
+function mailchimp_mailchimp_api_key_alter(&$api_key, $context) {
+  if (isset($_POST['mc_aid'])) {
+    $api_key = mailchimp_get_api_key_for_account($_POST['mc_aid']);
+  }
+}
+
+/**
  * Invokes hook_mailchimp_api_key so modules can declare keys.
  *
  * @return array
@@ -279,8 +290,7 @@ function mailchimp_account_select_form($form, &$form_state) {
       '#default_value' => (isset($_REQUEST['mc_aid'])) ? $_REQUEST['mc_aid'] : 'default',
     );
     $form['#action'] = $_SERVER['REQUEST_URI'];
-    $form['#method'] = 'get';
-    $form['#pre_render'][] = 'mailchimp_account_select_form_modify';
+    $form['#method'] = 'post';
     $form['submit'] = array(
       '#type' => 'submit',
       '#value' => t('Select'),
@@ -289,14 +299,8 @@ function mailchimp_account_select_form($form, &$form_state) {
   return $form;
 }
 
-/**
- * Removes unnecessary url variables.
- */
-function mailchimp_account_select_form_modify($form) {
-  unset($form['form_token']);
-  unset($form['form_build_id']);
-  unset($form['form_id']);
-  return $form;
+function mailchimp_account_select_form_submit($form, &$form_state) {
+  $form_state['rebuild'] = TRUE;
 }
 
 /**

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -50,7 +50,7 @@ function mailchimp_menu() {
 
   $items['admin/config/services/mailchimp'] = array(
     'title' => 'MailChimp',
-    'description' => t('Manage MailChimp Settings.'),
+    'description' => 'Manage MailChimp Settings.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('mailchimp_admin_settings'),
     'access arguments' => array('administer mailchimp'),
@@ -58,7 +58,7 @@ function mailchimp_menu() {
     'type' => MENU_NORMAL_ITEM,
   );
   $items['admin/config/services/mailchimp/global'] = array(
-    'title' => t('Global Settings'),
+    'title' => 'Global Settings',
     'type' => MENU_DEFAULT_LOCAL_TASK,
     'weight' => -10,
   );
@@ -117,9 +117,8 @@ function mailchimp_apikey_ready_access($permission) {
  *
  * @param string $classname
  *   The MailChimp library class to instantiate.
- *
  * @param string $api_key
- *   The MailChimp api key to use if not the default
+ *   The MailChimp api key to use if not the default.
  *
  * @return Mailchimp
  *   Instance of the MailChimp library class. Can be overridden by $classname.
@@ -168,7 +167,7 @@ function mailchimp_get_api_object($classname = 'Mailchimp', $api_key = NULL) {
   drupal_alter('mailchimp_api_key', $api_key, $context);
 
   if (!strlen($api_key)) {
-    watchdog('mailchimp', t('MailChimp Error: API Key cannot be blank.'), array(), WATCHDOG_ERROR);
+    watchdog('mailchimp', 'MailChimp Error: API Key cannot be blank.', array(), WATCHDOG_ERROR);
     return NULL;
   }
   // Set the timeout to something that won't take down the Drupal site:
@@ -182,20 +181,19 @@ function mailchimp_get_api_object($classname = 'Mailchimp', $api_key = NULL) {
 
 /**
  * Implements hook_mailchimp_api_key().
- *
- * @return array
- *   Since we don't know the default account_id, we use 'default'
  */
 function mailchimp_mailchimp_api_key() {
+  // We use 'default' since we don't know the default account id.
   return array('default' => variable_get('mailchimp_api_key', ''));
 }
 
 /**
- * Invokes hook_mailchimp_api_key so modules can declare keys
+ * Invokes hook_mailchimp_api_key so modules can declare keys.
  *
  * @return array
- *   The array_keys are the account id and the array_values are the api keys
- *   @see hook_mailchimp_api_key();
+ *   The array_keys are the account id and the array_values are the api keys.
+ *
+ * @see hook_mailchimp_api_key()
  */
 function mailchimp_api_keys() {
   $api_keys = module_invoke_all('mailchimp_api_key');
@@ -203,7 +201,7 @@ function mailchimp_api_keys() {
 }
 
 /**
- * Creates an array of working api accounts in the system
+ * Creates an array of working api accounts in the system.
  *
  * @return array
  *   The array_key is the account_id, the array_value is the account object.
@@ -221,11 +219,10 @@ function mailchimp_api_accounts() {
 /**
  * Wrapper around Mailchimp->getAccount().
  *
- * @param  object $api
- *   The api object to use, if already instantiated
- *
- * @param  string $api_key
- *   The api key to use to instantiate the MailChimp API object
+ * @param object $api
+ *   The api object to use, if already instantiated.
+ * @param string $api_key
+ *   The api key to use to instantiate the MailChimp API object.
  *
  * @return Object
  *   The MailChimp account object.
@@ -240,27 +237,30 @@ function mailchimp_api_account($api = NULL, $api_key = NULL) {
 /**
  * Returns the api key based on a given account id.
  *
- * @param  string $account_id
- *   The MailChimp account_id
- *   @see mailchimp_account_overview_page().
+ * @param string $account_id
+ *   The MailChimp account_id.
  *
  * @return string
  *   The api key registered via hook_mailchimp_api_key().
- *   @see hook_mailchimp_api_key().
+ *
+ * @see hook_mailchimp_api_key()
+ * @see mailchimp_account_overview_page()
  */
 function mailchimp_get_api_key_for_account($account_id) {
   $api_keys = mailchimp_api_keys();
   if (isset($api_keys[$account_id])) {
     return $api_keys[$account_id];
   }
-  watchdog('mailchimp', t('MailChimp Error: API Key not set for account @account_id.'), array('@account_id' => $account_id), WATCHDOG_ERROR);
+  watchdog('mailchimp', 'MailChimp Error: API Key not set for account @account_id.', array('@account_id' => $account_id), WATCHDOG_ERROR);
   return NULL;
 }
 
 /**
  * MailChimp account select form.
+ *
  * Enables switching between multiple keys.
- * @see hook_mailchimp_api_key().
+ *
+ * @see hook_mailchimp_api_key()
  */
 function mailchimp_account_select_form($form, &$form_state) {
   $form = array();
@@ -275,9 +275,9 @@ function mailchimp_account_select_form($form, &$form_state) {
       $options[$account_id] = $account->account_name;
     }
     $form['mc_aid'] = array(
-       '#type' => 'select',
-       '#options' => $options,
-       '#default_value' => 'default',
+      '#type' => 'select',
+      '#options' => $options,
+      '#default_value' => 'default',
     );
     $form['#action'] = $_SERVER['REQUEST_URI'];
     $form['#method'] = 'get';
@@ -291,9 +291,9 @@ function mailchimp_account_select_form($form, &$form_state) {
 }
 
 /**
- * Removes unnecessary url variables
+ * Removes unnecessary url variables.
  */
-function mailchimp_account_select_form_modify($form){
+function mailchimp_account_select_form_modify($form) {
   unset($form['form_token']);
   unset($form['form_build_id']);
   unset($form['form_id']);
@@ -374,7 +374,7 @@ function mailchimp_get_lists($list_ids = array(), $reset = FALSE) {
       }
       uasort($lists, '_mailchimp_list_cmp');
       $account = mailchimp_api_account($mc_lists);
-      cache_set('lists-' . $account->account_id , $lists, 'cache_mailchimp', CACHE_TEMPORARY);
+      cache_set('lists-' . $account->account_id, $lists, 'cache_mailchimp', CACHE_TEMPORARY);
     }
     catch (Exception $e) {
       watchdog('mailchimp', 'An error occurred requesting list information from MailChimp. "%message"', array(
@@ -549,7 +549,7 @@ function mailchimp_get_memberinfo($list_id, $email, $reset = FALSE) {
  * @param string $list_id
  *   Unique string identifier for the list on your MailChimp account.
  * @param string $email
- *   Email address to check for on the identified MailChimp List
+ *   Email address to check for on the identified MailChimp List.
  * @param bool $reset
  *   Set to TRUE to ignore the cache. (Used heavily in testing functions.)
  *
@@ -608,7 +608,7 @@ function mailchimp_subscribe_process($list_id, $email, $merge_vars = NULL, $inte
     }
 
     $parameters = array(
-      // If double opt-in is required, set member status to 'pending'
+      // If double opt-in is required, set member status to 'pending'.
       'status' => ($double_optin) ? \Mailchimp\MailchimpLists::MEMBER_STATUS_PENDING : \Mailchimp\MailchimpLists::MEMBER_STATUS_SUBSCRIBED,
       'email_type' => $format,
     );
@@ -920,10 +920,6 @@ function mailchimp_batch_update_members($list_id, $batch, $double_in = FALSE) {
  * @param bool $notify
  *   Indicates whether to send the unsubscribe notification email to the address
  *   defined in the list email notification settings.
- * @param object $mcapi
- *   MailChimp API object if one is already loaded.
- * @param bool $allow_async
- *   Set to TRUE to allow asynchronous processing using DrupalQueue.
  *
  * @return bool
  *   Indicates whether unsubscribe was successful.
@@ -1035,7 +1031,7 @@ function mailchimp_get_segments($list_id, $reset = NULL) {
  * @param string $name
  *   A label for the segment.
  * @param string $type
- *   'static' or 'saved'
+ *   'static' or 'saved'.
  * @param array $segment_options
  *   Array of options for 'saved' segments. See MailChimp API docs.
  *
@@ -1078,11 +1074,11 @@ function mailchimp_segment_create($list_id, $name, $type, $segment_options = NUL
  * Add a specific subscriber to a static segment of a list.
  *
  * @param string $list_id
- *   ID of a MailChimp list
+ *   ID of a MailChimp list.
  * @param string $segment_id
- *   ID of a segment of the MailChimp list
+ *   ID of a segment of the MailChimp list.
  * @param string $email
- *   Email address to add to the segment (does NOT subscribe to the list)
+ *   Email address to add to the segment (does NOT subscribe to the list).
  * @param bool $batch
  *   Whether to queue this for the batch processor. Defaults to TRUE.
  * @param string $queue_id
@@ -1123,11 +1119,11 @@ function mailchimp_segment_add_subscriber($list_id, $segment_id, $email, $batch 
  * Add a batch of email addresses to a static segment of a list.
  *
  * @param string $list_id
- *   ID of a MailChimp list
+ *   ID of a MailChimp list.
  * @param string $segment_id
- *   ID of a segment of the MailChimp list
+ *   ID of a segment of the MailChimp list.
  * @param array $batch
- *   Batch of email addresses to add to the segment (does NOT subscribe new)
+ *   Batch of email addresses to add to the segment (does NOT subscribe new).
  *
  * @return int
  *   Successful subscribe count
@@ -1305,7 +1301,7 @@ function mailchimp_webhook_add($list_id, $url, $events = array(), $sources = arr
     return $result->id;
   }
   catch (Exception $e) {
-    watchdog('mailchimp', t('An error occurred adding webhook for list @list. "%message"'), array(
+    watchdog('mailchimp', 'An error occurred adding webhook for list @list. "%message"', array(
       '@list' => $list_id,
       '%message' => $e->getMessage(),
     ), WATCHDOG_ERROR);
@@ -1461,7 +1457,6 @@ function mailchimp_webhook_url() {
   return $GLOBALS['base_url'] . '/mailchimp/webhook/' . mailchimp_webhook_key();
 }
 
-
 /**
  * Helper function to generate form elements for a list's interest groups.
  *
@@ -1525,7 +1520,7 @@ function mailchimp_interest_groups_form_elements($list, $defaults = array(), $em
           $default_values[$group->id][] = $interest->id;
         }
       }
-      else if (!empty($defaults)) {
+      elseif (!empty($defaults)) {
         if (isset($defaults[$group->id][$interest->id]) && !empty($defaults[$group->id][$interest->id])) {
           $default_values[$group->id][] = $interest->id;
         }
@@ -1598,6 +1593,7 @@ function mailchimp_insert_drupal_form_tag($mergevar) {
         '#maxlength' => 2,
       );
       break;
+
     case 'dropdown':
       // Dropdown is mapped to <select> element in Drupal Form API.
       $input['#type'] = 'select';

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -156,15 +156,14 @@ function mailchimp_get_api_object($classname = 'Mailchimp', $api_key = NULL) {
     return NULL;
   }
 
-  if (!$api_key) {
-    $api_key = (isset($_REQUEST['mc_aid']))
-      ? mailchimp_get_api_key_for_account(check_plain($_REQUEST['mc_aid']))
-      : variable_get('mailchimp_api_key', '');
-  }
   $context = array(
     'api_class' => $classname,
   );
-  drupal_alter('mailchimp_api_key', $api_key, $context);
+  if (!$api_key) {
+    $api_key = variable_get('mailchimp_api_key', '');
+    // Allow modules to alter the default.
+    drupal_alter('mailchimp_api_key', $api_key, $context);
+  }
 
   if (!strlen($api_key)) {
     watchdog('mailchimp', 'MailChimp Error: API Key cannot be blank.', array(), WATCHDOG_ERROR);

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -274,12 +274,11 @@ function mailchimp_get_api_key_for_account($account_id) {
  */
 function mailchimp_account_select_form($form, &$form_state) {
   $form = array();
-  $account = mailchimp_api_account();
-  $form['heading'] = array(
-    '#markup' => '<h2>' . $account->account_name . '</h2>',
-  );
   $accounts = mailchimp_api_accounts();
   if (count($accounts) > 1) {
+    $form['heading'] = array(
+      '#markup' => '<h3>'. t('MailChimp Account') . '</h3>',
+    );
     $options = array();
     foreach ($accounts as $account_id => $account) {
       $options[$account_id] = $account->account_name;

--- a/modules/mailchimp_lists/includes/mailchimp_lists.admin.inc
+++ b/modules/mailchimp_lists/includes/mailchimp_lists.admin.inc
@@ -10,6 +10,10 @@
  */
 function mailchimp_lists_overview_page() {
   $mc_lists = mailchimp_get_lists();
+  $account = mailchimp_api_account();
+  $output = '<h2>' . $account->account_name . '</h2>';
+  $account_select_form = drupal_get_form('mailchimp_account_select_form');
+  $output .= drupal_render($account_select_form);
   $rows = array();
   $webhook_url = mailchimp_webhook_url();
   foreach ($mc_lists as $mc_list) {
@@ -63,7 +67,8 @@ function mailchimp_lists_overview_page() {
     $table['caption'] = $options;
   }
 
-  return theme('table', $table);
+  $output .= theme('table', $table);
+  return $output;
 }
 
 /**

--- a/modules/mailchimp_lists/includes/mailchimp_lists.admin.inc
+++ b/modules/mailchimp_lists/includes/mailchimp_lists.admin.inc
@@ -10,10 +10,6 @@
  */
 function mailchimp_lists_overview_page() {
   $mc_lists = mailchimp_get_lists();
-  $account = mailchimp_api_account();
-  $output = '<h2>' . $account->account_name . '</h2>';
-  $account_select_form = drupal_get_form('mailchimp_account_select_form');
-  $output .= drupal_render($account_select_form);
   $rows = array();
   $webhook_url = mailchimp_webhook_url();
   foreach ($mc_lists as $mc_list) {
@@ -67,8 +63,7 @@ function mailchimp_lists_overview_page() {
     $table['caption'] = $options;
   }
 
-  $output .= theme('table', $table);
-  return $output;
+  return theme('table', $table);
 }
 
 /**


### PR DESCRIPTION
Sorry, re-doing PR as I was working from the wrong base branch.

I've added two commits based on feedback from our email correspondence regarding supporting multiple mailchimp account api keys.

Your suggestions regarding adding hooks for the api key and cache clearing provided a good starting point. However, for our use case, we needed a bit more than just two hooks. I ended up adding 3 hooks, in addition to a function that a developer could call to clear all mailchimp caches. You can see the hooks documented in mailchimp.api.php.

I'm happy to try to explain the code that was added (and logic behind it) if that would be useful. I suggest we use the github "Files changed" tab to start the conversation, but am open to other suggestions. In particular, you'll notice that mailchimp_get_api_object provides a few ways of modifying the api key, which changes depending on the situation. You can now pass an api_key as a parameter, or as a url variable ($_REQUEST['mc_aid']), or through an alter hook. All three were important for our use case, so I'm hoping to talk through any questions or issues you have with this approach.

The 2nd commit provides an example of how the mailchimp_account_select_form could be used to add custom code to add the account select menu to an administrative page (for example, the field configuration of a given mailchimp subscription form, or the mailchimp lists page in this example).

Thanks in advance for your willingness to consider this and suggesting an approach. Please let me know if/when you want me to add this as a patch on D.O.
