### PR TITLE
Added mailchimp_automations submodule and updated api docs

### DIFF
--- a/mailchimp.api.php
+++ b/mailchimp.api.php
@@ -56,3 +56,43 @@ function hook_mailchimp_subscribe_user($list_id, $email, $merge_vars) {
 function hook_mailchimp_unsubscribe_user($list_id, $email) {
 
 }
+
+/**
+ * Alter the entity options list on the automations entity form.
+ *
+ * @param array $entity_type_options
+ *   The full list of Drupal entities.
+ * @param string $automation_entity_label
+ *   The label for the automation entity, if it exists.
+ */
+function hook_mailchimp_automations_entity_options(&$entity_type_options, $automation_entity_label) {
+
+}
+
+/**
+ * Alter mergevars before a workflow automation is triggered.
+ *
+ * @param array $merge_vars
+ *   The merge vars that will be passed to MailChimp.
+ * @param object $automation_entity
+ *   The MailchimpAutomationEntity object.
+ * @param object $wrapped_entity
+ *   The EntityMetadataWrapper for the triggering entity.
+ */
+function hook_mailchimp_automations_mergevars_alter(&$merge_vars, $automation_entity, $wrapped_entity) {
+}
+
+/**
+ * Perform an action after a successful MailChimp workflow automation.
+ *
+ * @param object $automation_entity
+ *   The MailchimpAutomationEntity object.
+ * @param string $email
+ *   The email_property value from the MailchimpAutomationEntity.
+ * @param object $wrapped_entity
+ *   The EntityMetadataWrapper for the triggering entity.
+ */
+function hook_mailchimp_automations_workflow_email_triggered($automation_entity, $email, $wrapped_entity) {
+
+}
+

--- a/modules/mailchimp_automations/README.txt
+++ b/modules/mailchimp_automations/README.txt
@@ -1,0 +1,26 @@
+Integrate your Drupal entities with MailChimp's workflow automation endpoints.
+
+## Installation
+
+1. Enable the MailChimp Automation module
+2. Make sure you have a recent version of the MailChimp PHP API library, which includes the MailchimpAutomations API service.
+
+## Usage
+
+1. Define which entity types you want to show campaign activity for at
+/admin/config/services/mailchimp/automations.
+  * Select a Drupal entity type.
+  * Select a bundle.
+  * Select the email entity property.
+  * Select the appropriate MailChimp List
+  * Select the appropriate MailChimp Workflow
+  * Select the appropriate MailChimp Workflow Email
+2. Configure permissions for managing MailChimp Automations
+
+## Notes
+
+1. The "Import mailchimp automation entity" button on the Automations admin tab will
+throw a PHP error due to a bug in Entity API. You can prevent this error by
+applying the patch in https://drupal.org/comment/8648215#comment-8648215 to
+the entity module.
+2. See additional options in the mailchimp_automations.api.php file, such as passing merge variables to MailChimp.

--- a/modules/mailchimp_automations/includes/mailchimp_automations.admin.inc
+++ b/modules/mailchimp_automations/includes/mailchimp_automations.admin.inc
@@ -167,7 +167,7 @@ function mailchimp_automations_entity_form($form, &$form_state, MailchimpAutomat
               '#options' => $automation_options,
               '#default_value' => $entitynotnull ? $mailchimp_automations_entity->workflow_id : 0,
               '#maxlength' => 127,
-              '#weight' => -5,
+              '#weight' => -4,
               '#ajax' => array(
                 'callback' => 'mailchimp_automations_mapping_form_callback',
                 'wrapper' => 'mailchimp-automation-drupal-entity',
@@ -196,7 +196,7 @@ function mailchimp_automations_entity_form($form, &$form_state, MailchimpAutomat
                 '#options' => $emails,
                 '#default_value' => $entitynotnull ? $mailchimp_automations_entity->workflow_email_id : 0,
                 '#maxlength' => 127,
-                '#weight' => -4,
+                '#weight' => -3,
               );
             }
             else {

--- a/modules/mailchimp_automations/includes/mailchimp_automations.admin.inc
+++ b/modules/mailchimp_automations/includes/mailchimp_automations.admin.inc
@@ -1,0 +1,335 @@
+<?php
+
+/**
+ * @file
+ * Administration pages for mailchimp_automations module.
+ */
+
+/**
+ * Returns a form for a mailchimp_automations_entity.
+ */
+function mailchimp_automations_entity_form($form, &$form_state, MailchimpAutomationsEntity $mailchimp_automations_entity = NULL, $op = 'edit') {
+  if ($op == 'clone') {
+    $mailchimp_automations_entity->label .= ' (cloned)';
+    $mailchimp_automations_entity->name = '';
+  }
+  $entitynotnull = isset($mailchimp_automations_entity->mailchimp_automations_entity_id);
+  $form_state['mailchimp_automation'] = $mailchimp_automations_entity;
+
+  $form['label'] = array(
+    '#title' => t('Label'),
+    '#type' => 'textfield',
+    '#default_value' => $entitynotnull ? $mailchimp_automations_entity->label : '',
+    '#description' => t('The human-readable name of this automation entity.'),
+    '#required' => TRUE,
+    '#weight' => -10,
+  );
+
+  $form['name'] = array(
+    '#title' => t('Name'),
+    '#type' => 'machine_name',
+    '#default_value' => $entitynotnull ? $mailchimp_automations_entity->name : '',
+    '#description' => t('machine name should only contain lowercase letters & underscores'),
+    '#disabled' => !empty($mailchimp_automations_entity->name),
+    '#required' => TRUE,
+    '#machine_name' => array(
+      'exists' => 'mailchimp_automations_load_entities',
+      'source' => array('label'),
+    ),
+    '#weight' => -9,
+  );
+
+  $form['drupal_entity'] = array(
+    '#title' => t('Drupal entity'),
+    '#type' => 'fieldset',
+    '#attributes' => array(
+      'id' => array('mailchimp-automation-drupal-entity'),
+    ),
+    '#weight' => -8,
+  );
+  // Prep the entity type list before creating the form item:
+  $entity_types = array('' => t('-- Select --'));
+  foreach (entity_get_info() as $entity_type => $info) {
+    // Ignore MailChimp entity types:
+    if (strpos($entity_type, 'mailchimp') === FALSE) {
+      $entity_types[$entity_type] = $info['label'];
+    }
+  }
+  $automation_entity_label = $entitynotnull ? $mailchimp_automations_entity->label : '';
+  drupal_alter('mailchimp_automations_entity_options', $entity_types, $automation_entity_label);
+  asort($entity_types);
+  $form['drupal_entity']['entity_type'] = array(
+    '#title' => t('Entity type'),
+    '#type' => 'select',
+    '#options' => $entity_types,
+    '#default_value' => $entitynotnull ? $mailchimp_automations_entity->entity_type : 0,
+    '#required' => TRUE,
+    '#description' => t('Select an entity type to trigger a mailchimp automation.'),
+    '#ajax' => array(
+      'callback' => 'mailchimp_automations_mapping_form_callback',
+      'wrapper' => 'mailchimp-automation-drupal-entity',
+    ),
+    '#weight' => -8,
+  );
+
+  $form_entity_type = & $form_state['values']['entity_type'];
+  if (!$form_entity_type && $entitynotnull) {
+    $form_entity_type = $mailchimp_automations_entity->entity_type;
+  }
+  if ($form_entity_type) {
+    // Prep the bundle list before creating the form item:
+    $bundles = array('' => t('-- Select --'));
+    $info  = entity_get_info($form_entity_type);
+    foreach ($info['bundles'] as $key => $bundle) {
+      $bundles[$key] = $bundle['label'];
+    }
+    asort($bundles);
+    $form['drupal_entity']['bundle'] = array(
+      '#title' => t('Entity bundle'),
+      '#type' => 'select',
+      '#required' => TRUE,
+      '#description' => t('Select a Drupal entity bundle with an email address to report on.'),
+      '#options' => $bundles,
+      '#default_value' => $entitynotnull ? $mailchimp_automations_entity->bundle : 0,
+      '#weight' => -7,
+      '#ajax' => array(
+        'callback' => 'mailchimp_automations_mapping_form_callback',
+        'wrapper' => 'mailchimp-automation-drupal-entity',
+      ),
+    );
+
+    $form_bundle = & $form_state['values']['bundle'];
+    if (!$form_bundle && $entitynotnull) {
+      $form_bundle = $mailchimp_automations_entity->bundle;
+    }
+    if ($form_bundle) {
+      // Prep the field & properties list before creating the form item:
+      $fields = mailchimp_automations_email_fieldmap_options($form_entity_type, $form_bundle);
+      $form['drupal_entity']['email_property'] = array(
+        '#title' => t('Email Property'),
+        '#type' => 'select',
+        '#required' => TRUE,
+        '#description' => t('Select the field which contains the email address'),
+        '#options' => $fields,
+        '#default_value' => $entitynotnull ? $mailchimp_automations_entity->email_property : 0,
+        '#maxlength' => 127,
+        '#weight' => -6,
+        '#ajax' => array(
+          'callback' => 'mailchimp_automations_mapping_form_callback',
+          'wrapper' => 'mailchimp-automation-drupal-entity',
+        ),
+      );
+
+      $form_email_property = & $form_state['values']['email_property'];
+      if (!$form_email_property && $entitynotnull) {
+        $form_email_property = $mailchimp_automations_entity->email_property;
+      }
+      if ($form_email_property) {
+        $mc_lists = mailchimp_get_lists();
+        $options = array(t('-- Select --'));
+        foreach ($mc_lists as $list_id => $list) {
+          $options[$list_id] = $list->name;
+        }
+        if (!empty($options)) {
+          $form['drupal_entity']['list_id'] = array(
+            '#title' => t('MailChimp List'),
+            '#type' => 'select',
+            '#required' => TRUE,
+            '#description' => t('Select the list that you created in MailChimp.'),
+            '#options' => $options,
+            '#default_value' => $entitynotnull ? $mailchimp_automations_entity->list_id : 0,
+            '#maxlength' => 127,
+            '#weight' => -5,
+            '#ajax' => array(
+              'callback' => 'mailchimp_automations_mapping_form_callback',
+              'wrapper' => 'mailchimp-automation-drupal-entity',
+            ),
+          );
+        }
+        else {
+          $msg = t('You must add at least one list in MailChimp for this functionality to work.');
+          drupal_set_message($msg, 'error', FALSE);
+        }
+
+        $form_list_id = & $form_state['values']['list_id'];
+        if (!$form_list_id && $entitynotnull) {
+          $form_list_id = $mailchimp_automations_entity->list_id;
+        }
+        if ($form_list_id) {
+          $automations = mailchimp_automations_get_automations();
+          if (!empty($automations)) {
+            $automation_options = mailchimp_automations_options_list($automations);
+            $form['drupal_entity']['workflow_id'] = array(
+              '#title' => t('Workflow ID'),
+              '#type' => 'select',
+              '#required' => TRUE,
+              '#description' => t('Select the workflow automation that you created in MailChimp. Untitled workflows are not included.'),
+              '#options' => $automation_options,
+              '#default_value' => $entitynotnull ? $mailchimp_automations_entity->workflow_id : 0,
+              '#maxlength' => 127,
+              '#weight' => -5,
+              '#ajax' => array(
+                'callback' => 'mailchimp_automations_mapping_form_callback',
+                'wrapper' => 'mailchimp-automation-drupal-entity',
+              ),
+            );
+          }
+          else {
+            $msg = t('You must add at least one workflow in MailChimp for this functionality to work.');
+            drupal_set_message($msg, 'error', FALSE);
+          }
+
+          $form_workflow_id = & $form_state['values']['workflow_id'];
+          if (!$form_workflow_id && $entitynotnull) {
+            $form_workflow_id = $mailchimp_automations_entity->workflow_id;
+          }
+          if ($form_workflow_id) {
+            // Once the workflow id is saved, add the workflow email options.
+            $emails = mailchimp_automations_get_emails_for_workflow($form_workflow_id);
+            if (!empty($emails)) {
+              array_unshift($emails, t('-- Select --'));
+              $form['drupal_entity']['workflow_email_id'] = array(
+                '#title' => t('Workflow Email ID'),
+                '#type' => 'select',
+                '#required' => TRUE,
+                '#description' => t('Select the workflow automation email that you created in MailChimp.'),
+                '#options' => $emails,
+                '#default_value' => $entitynotnull ? $mailchimp_automations_entity->workflow_email_id : 0,
+                '#maxlength' => 127,
+                '#weight' => -4,
+              );
+            }
+            else {
+              $msg = t('You must add at least one workflow email in MailChimp for this functionality to work.');
+              drupal_set_message($msg, 'error', FALSE);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  $form['actions'] = array('#type' => 'actions');
+  $form['actions']['submit'] = array(
+    '#value' => t('Save Entity'),
+    '#type' => 'submit',
+  );
+
+  return $form;
+}
+
+/**
+ * Creates the options array for the select menu.
+ */
+function mailchimp_automations_options_list($automations) {
+  $options = array(t('-- Select --'));
+  foreach ($automations as $workflow) {
+    $title = $workflow->settings->title;
+    if (!empty($title)) {
+      $options[$workflow->id] = $title;
+    }
+  }
+  return $options;
+}
+
+/**
+ * Ajax callback for mailchimp_automations_mapping_form().
+ */
+function mailchimp_automations_mapping_form_callback($form, &$form_state) {
+  return $form['drupal_entity'];
+}
+
+/**
+ * Validation callback for mailchimp_automations_entity_form().
+ */
+function mailchimp_automations_entity_form_validate($form, &$form_state) {
+  if ($form_state['submitted']) {
+    $extant_mc_entities = entity_load('mailchimp_automations_entity');
+    $form_id = $form_state['mailchimp_automations_entity']->mailchimp_automations_entity_id;
+    $form_bundle = $form_state['values']['bundle'];
+    $form_entity_id = $form_state['values']['entity_type'];
+    foreach ($extant_mc_entities as $extant_ent) {
+      if ($form_bundle == $extant_ent->bundle &&
+          $form_entity_id == $extant_ent->entity_type &&
+          $form_id != $extant_ent->mailchimp_automations_entity_id) {
+        form_set_error(
+          'bundle',
+          t('A MailChimp Automation Entity already exists for this Bundle. Either select a different Bundle or edit the !link for this bundle.',
+            array(
+              '!link' => l(t('existing MailChimp Automation Entity'), "admin/config/services/mailchimp/automations/manage/{$extant_ent->name}"),
+            )
+          ));
+      }
+    }
+  }
+}
+
+/**
+ * Submit handler for mailchimp_automations_entity_form().
+ */
+function mailchimp_automations_entity_form_submit($form, &$form_state) {
+  $dummy_entity = entity_create($form_state['values']['entity_type'], array('type' => $form_state['values']['bundle']));
+  $entity_info = entity_get_info($dummy_entity->type);
+  if (!empty($entity_info)) {
+    // Create empty entity ID field so entity_uri doesn't result in an error.
+    $entity_id_field = $entity_info['entity keys']['id'];
+    $dummy_entity->$entity_id_field = NULL;
+  }
+  $uri = entity_uri($form_state['values']['entity_type'], $dummy_entity);
+  $values = $form_state['values'];
+  if ($form_state['op'] == 'add' || $form_state['op'] == 'clone') {
+    $automation_entity = entity_create('mailchimp_automations_entity', $values);
+  }
+  else {
+    $automation_entity = $form_state['mailchimp_automations_entity'];
+    foreach ($values as $key => $val) {
+      $automation_entity->{$key} = $val;
+    }
+  }
+  $automation_entity->save();
+  // Make sure the new items appear in the menus:
+  menu_rebuild();
+  $form_state['redirect'] = 'admin/config/services/mailchimp/automations';
+}
+
+/**
+ * Return all possible Drupal properties for a given entity type.
+ *
+ * @param string $entity_type
+ *   Name of entity whose properties to list.
+ * @param string $entity_bundle
+ *   Optional entity bundle to get properties for.
+ *
+ * @return array
+ *   List of entities that can be used as an #options list.
+ */
+function mailchimp_automations_email_fieldmap_options($entity_type, $entity_bundle = NULL) {
+  $options = array('' => t('-- Select --'));
+
+  $properties = entity_get_all_property_info($entity_type);
+  if (isset($entity_bundle)) {
+    $info = entity_get_property_info($entity_type);
+    $properties = $info['properties'];
+    if (isset($info['bundles'][$entity_bundle])) {
+      $properties += $info['bundles'][$entity_bundle]['properties'];
+    }
+  }
+
+  foreach ($properties as $key => $property) {
+    $type = isset($property['type']) ? entity_property_extract_innermost_type($property['type']) : 'text';
+    $is_entity = ($type == 'entity') || (bool) entity_get_info($type);
+    // Leave entities out of this.
+    if (!$is_entity) {
+      if (isset($property['field']) && $property['field'] && !empty($property['property info'])) {
+        foreach ($property['property info'] as $sub_key => $sub_prop) {
+          $options[$property['label']][$key . ':' . $sub_key] = $sub_prop['label'];
+        }
+      }
+      else {
+        $options[$key] = $property['label'];
+      }
+    }
+  }
+
+  return $options;
+}

--- a/modules/mailchimp_automations/includes/mailchimp_automations.entity.inc
+++ b/modules/mailchimp_automations/includes/mailchimp_automations.entity.inc
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * Mailchimp Automations entity class.
+ */
+
+class MailchimpAutomationsEntity extends Entity {
+  public
+    $mailchimp_automations_entity_id,
+    $name,
+    $label,
+    $entity_type,
+    $bundle,
+    $email_property,
+    $list_id,
+    $workflow_id,
+    $workflow_email_id;
+
+  /**
+   * Basic __construct implementation.
+   */
+  public function __construct(array $values = array()) {
+    parent::__construct($values, 'mailchimp_automations_entity');
+  }
+
+  /**
+   * Overrides Entity\Entity::uri().
+   */
+  public function uri() {
+    return array(
+      'path' => 'admin/config/services/mailchimp/automations/manage/' . $this->name,
+      'options' => array(
+        'entity_type' => $this->entityType,
+        'entity' => $this,
+      ),
+    );
+  }
+
+}

--- a/modules/mailchimp_automations/includes/mailchimp_automations.ui_controller.inc
+++ b/modules/mailchimp_automations/includes/mailchimp_automations.ui_controller.inc
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Class file for Mailchimp Automation UI Controller.
+ */
+
+/**
+ * Override EntityDefaultUIController to customize our menu items.
+ */
+class MailChimpAutomationUIController extends EntityDefaultUIController {
+
+  /**
+   * Overrides parent::hook_menu().
+   */
+  public function hook_menu() {
+    $items = parent::hook_menu();
+    $items[$this->path]['description'] = 'Manage MailChimp Automation entity settings.';
+    $items[$this->path]['type'] = MENU_LOCAL_TASK;
+    $items[$this->path]['access callback'] = 'mailchimp_automations_entity_access';
+    $items[$this->path]['title'] = "Automations";
+    $items[$this->path]['weight'] = 10;
+    return $items;
+  }
+
+}

--- a/modules/mailchimp_automations/mailchimp_automations.info
+++ b/modules/mailchimp_automations/mailchimp_automations.info
@@ -1,0 +1,10 @@
+name = MailChimp Automations
+description = Add workflow automations for any entity with an email field.
+package = MailChimp
+core = 7.x
+
+dependencies[] = mailchimp
+dependencies[] = entity
+
+files[] = includes/mailchimp_automations.entity.inc
+files[] = includes/mailchimp_automations.ui_controller.inc

--- a/modules/mailchimp_automations/mailchimp_automations.install
+++ b/modules/mailchimp_automations/mailchimp_automations.install
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the mailchimp_automations module.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function mailchimp_automations_schema() {
+
+  $schema['mailchimp_automations_entity'] = array(
+    'description' => t('MailChimp automation enabled entities.'),
+    'fields' => array(
+      'mailchimp_automations_entity_id' => array(
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => t('Primary Key: Unique mailchimp_automations_entity entity ID.'),
+      ),
+      'name' => array(
+        'description' => t('The machine-readable name of this mailchimp_automations_entity.'),
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+      ),
+      'label' => array(
+        'description' => t('The human-readable name of this mailchimp_automations_entity.'),
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+      ),
+      'entity_type' => array(
+        'description' => t('The Drupal entity type (e.g. "node", "user").'),
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'bundle' => array(
+        'description' => t('The Drupal bundle (e.g. "page", "user")'),
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'email_property' => array(
+        'description' => t('The property that contains the email address to send to mailchimp.'),
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'list_id' => array(
+        'description' => t('The MailChimp automation list id.'),
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'workflow_id' => array(
+        'description' => t('The MailChimp automation workflow id.'),
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'workflow_email_id' => array(
+        'description' => t('The MailChimp automation workflow email id.'),
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      // The following fields are for supporting exportable status.
+      'locked' => array(
+        'description' => t('A boolean indicating whether the administrator may delete this mapping.'),
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+        'size' => 'tiny',
+      ),
+      'status' => array(
+        'type' => 'int',
+        'not null' => TRUE,
+        // Set the default to ENTITY_CUSTOM without using the constant as it is
+        // not safe to use it at this point.
+        'default' => 0x01,
+        'size' => 'tiny',
+        'description' => t('The exportable status of the entity.'),
+      ),
+      'module' => array(
+        'description' => t('The name of the providing module if the entity has been defined in code.'),
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ),
+    ),
+    'primary key' => array('mailchimp_automations_entity_id'),
+    'unique keys' => array(
+      'name' => array('name'),
+      'entity_type_bundle' => array(
+        'entity_type',
+        'bundle',
+      ),
+    ),
+  );
+
+  return $schema;
+}

--- a/modules/mailchimp_automations/mailchimp_automations.install
+++ b/modules/mailchimp_automations/mailchimp_automations.install
@@ -11,62 +11,62 @@
 function mailchimp_automations_schema() {
 
   $schema['mailchimp_automations_entity'] = array(
-    'description' => t('MailChimp automation enabled entities.'),
+    'description' => 'MailChimp automation enabled entities.',
     'fields' => array(
       'mailchimp_automations_entity_id' => array(
         'type' => 'serial',
         'not null' => TRUE,
-        'description' => t('Primary Key: Unique mailchimp_automations_entity entity ID.'),
+        'description' => 'Primary Key: Unique mailchimp_automations_entity entity ID.',
       ),
       'name' => array(
-        'description' => t('The machine-readable name of this mailchimp_automations_entity.'),
+        'description' => 'The machine-readable name of this mailchimp_automations_entity.',
         'type' => 'varchar',
         'length' => 128,
         'not null' => TRUE,
       ),
       'label' => array(
-        'description' => t('The human-readable name of this mailchimp_automations_entity.'),
+        'description' => 'The human-readable name of this mailchimp_automations_entity.',
         'type' => 'varchar',
         'length' => 128,
         'not null' => TRUE,
       ),
       'entity_type' => array(
-        'description' => t('The Drupal entity type (e.g. "node", "user").'),
+        'description' => 'The Drupal entity type (e.g. "node", "user").',
         'type' => 'varchar',
         'length' => 128,
         'not null' => TRUE,
         'default' => '',
       ),
       'bundle' => array(
-        'description' => t('The Drupal bundle (e.g. "page", "user")'),
+        'description' => 'The Drupal bundle (e.g. "page", "user")',
         'type' => 'varchar',
         'length' => 128,
         'not null' => TRUE,
         'default' => '',
       ),
       'email_property' => array(
-        'description' => t('The property that contains the email address to send to mailchimp.'),
+        'description' => 'The property that contains the email address to send to mailchimp.',
         'type' => 'varchar',
         'length' => 128,
         'not null' => TRUE,
         'default' => '',
       ),
       'list_id' => array(
-        'description' => t('The MailChimp automation list id.'),
+        'description' => 'The MailChimp automation list id.',
         'type' => 'varchar',
         'length' => 128,
         'not null' => TRUE,
         'default' => '',
       ),
       'workflow_id' => array(
-        'description' => t('The MailChimp automation workflow id.'),
+        'description' => 'The MailChimp automation workflow id.',
         'type' => 'varchar',
         'length' => 128,
         'not null' => TRUE,
         'default' => '',
       ),
       'workflow_email_id' => array(
-        'description' => t('The MailChimp automation workflow email id.'),
+        'description' => 'The MailChimp automation workflow email id.',
         'type' => 'varchar',
         'length' => 128,
         'not null' => TRUE,
@@ -74,7 +74,7 @@ function mailchimp_automations_schema() {
       ),
       // The following fields are for supporting exportable status.
       'locked' => array(
-        'description' => t('A boolean indicating whether the administrator may delete this mapping.'),
+        'description' => 'A boolean indicating whether the administrator may delete this mapping.',
         'type' => 'int',
         'not null' => TRUE,
         'default' => 0,
@@ -87,10 +87,10 @@ function mailchimp_automations_schema() {
         // not safe to use it at this point.
         'default' => 0x01,
         'size' => 'tiny',
-        'description' => t('The exportable status of the entity.'),
+        'description' => 'The exportable status of the entity.',
       ),
       'module' => array(
-        'description' => t('The name of the providing module if the entity has been defined in code.'),
+        'description' => 'The name of the providing module if the entity has been defined in code.',
         'type' => 'varchar',
         'length' => 255,
         'not null' => FALSE,

--- a/modules/mailchimp_automations/mailchimp_automations.module
+++ b/modules/mailchimp_automations/mailchimp_automations.module
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * @file
+ * Module file for mailchimp_automations.
+ */
+
+/**
+ * Implements hook_entity_info().
+ */
+function mailchimp_automations_entity_info() {
+  $return = array(
+    'mailchimp_automations_entity' => array(
+      'label' => t('MailChimp Automations Entity'),
+      'plural label' => t('MailChimp Automations Entities'),
+      'controller class' => 'EntityAPIControllerExportable',
+      'entity class' => 'MailchimpAutomationsEntity',
+      'base table' => 'mailchimp_automations_entity',
+      'uri callback' => 'entity_class_uri',
+      'fieldable' => FALSE,
+      'exportable' => TRUE,
+      'module' => 'mailchimp_automations',
+      'entity keys' => array(
+        'id' => 'mailchimp_automations_entity_id',
+        'name' => 'name',
+        'label' => 'label',
+      ),
+      // Enable the entity API's admin UI.
+      'admin ui' => array(
+        'path' => 'admin/config/services/mailchimp/automations',
+        'file' => 'includes/mailchimp_automations.admin.inc',
+        'controller class' => 'MailChimpAutomationUIController',
+      ),
+      'label callback' => 'mailchimp_automations_entity_info_label',
+      'access callback' => 'mailchimp_automations_entity_access',
+    ),
+  );
+
+  return $return;
+}
+
+/**
+ * Entity label callback.
+ */
+function mailchimp_automations_entity_info_label($entity, $entity_type) {
+  return empty($entity) ? 'New MailChimp Automation' : $entity->label;
+}
+
+/**
+ * Access callback for mailchimp_automations_entity.
+ */
+function mailchimp_automations_entity_access() {
+  return mailchimp_apikey_ready_access('administer mailchimp automations');
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function mailchimp_automations_entity_insert($entity, $type) {
+  $wrapper = entity_metadata_wrapper($type, $entity);
+  $bundle = $wrapper->getBundle();
+  if ($automation_entity = mailchimp_automations_entity_automation($type, $bundle)) {
+    mailchimp_automations_trigger_workflow($automation_entity, $wrapper);
+  }
+}
+
+/**
+ * Access callback for activity menu items.
+ */
+function mailchimp_automations_access(MailchimpAutomationsEntity $mailchimp_automations_entity) {
+  if (user_access('access mailchimp automations')) {
+    return TRUE;
+  }
+  return FALSE;
+}
+
+/**
+ * Loads a single or multiple instances of MailchimpAutomationsEntity.
+ *
+ * @param string $name
+ *   Optional name of the MailchimpAutomationsEntity instance to load.
+ *
+ * @return mixed
+ *   Array of MailchimpAutomationsEntity instances or one instance if $name is set.
+ */
+function mailchimp_automations_load_entities($id = NULL) {
+  $types = entity_load_multiple_by_name('mailchimp_automations_entity', isset($id) ? array($id) : FALSE);
+  return isset($id) ? reset($types) : $types;
+}
+
+/**
+ * Wrapper for MailchimpAutomations->getAutomations().
+ *
+ * @param string $workflow_id
+ *   The MailChimp workflow_id.
+ *
+ * @return array
+ *   The workflow automations for the active MailChimp API account.
+ */
+function mailchimp_automations_get_automations() {
+  $mc_auto = mailchimp_get_api_object('MailchimpAutomations');
+  $results = $mc_auto->getAutomations();
+  return $results->automations;
+}
+
+/**
+ * Wrapper for MailchimpAutomations->getWorkflow().
+ *
+ * @param string $workflow_id
+ *   The MailChimp workflow_id.
+ *
+ * @return array
+ *   The $key is workflow_id and the $value is the
+ */
+function mailchimp_automations_get_automation($workflow_id) {
+  $mc_auto = mailchimp_get_api_object('MailchimpAutomations');
+  $workflow = $mc_auto->getWorkflow($workflow_id);
+  $title = $worflow->settings->title;
+  if (!empty($title)) {
+    return array(
+      $workflow->id => $title,
+    );
+  }
+  return NULL;
+}
+
+/**
+ * Wrapper for MailchimpAutomations->getWorkflowEmails().
+ *
+ * @param string $workflow_id
+ *   The MailChimp workflow_id.
+ *
+ * @return array
+ *   An array of email workflows associated with this automation.
+ */
+function mailchimp_automations_get_emails_for_workflow($workflow_id) {
+  $emails = array();
+  $mc_auto = mailchimp_get_api_object('MailchimpAutomations');
+  $results = $mc_auto->getWorkflowEmails($workflow_id);
+  $email_results = $results->emails;
+  foreach ($email_results as $email) {
+    $title = $email->settings->title;
+    if (!empty($title)) {
+      $emails[$email->id] = $title;
+    }
+  }
+  return $emails;
+}
+
+/**
+ * Triggers a workflow automation via the MailChimp API.
+ *
+ * @param object $automation
+ *   The MailchimpAutomationsEntity object from the database.
+ * @param EntityMetadataWrapper $wrapped_entity
+ *   The wrapped entity that triggered the workflow automation.
+ */
+function mailchimp_automations_trigger_workflow($automation_entity, $wrapped_entity) {
+  $email_property_field = $automation_entity->email_property;
+  $email = $wrapped_entity->$email_property_field->value();
+  if (!mailchimp_is_subscribed($automation_entity->list_id, $email)) {
+    $merge_vars = NULL;
+    drupal_alter('mailchimp_automations_mergevars', $merge_vars, $automation_entity, $wrapped_entity);
+    // Skip mailchimp_subscribe to avoid cron if set
+    $added = mailchimp_subscribe_process($automation_entity->list_id, $email, $merge_vars);
+    if (!$added) {
+      watchdog('mailchimp', 'An error occurred subscribing @email to list @list during a workflow @automation. The automation did not comlplete.', array(
+        '@automation' => $automation_entity->label,
+        '@email' => $email,
+      ), WATCHDOG_ERROR);
+    }
+  }
+  $mc_auto = mailchimp_get_api_object('MailchimpAutomations');
+  try {
+    $result = $mc_auto->addWorkflowEmailSubscriber($automation_entity->workflow_id, $automation_entity->workflow_email_id, $email);
+    if ($result) {
+      module_invoke_all('mailchimp_automations_workflow_email_triggered', $automation_entity, $email, $wrapped_entity);
+    }
+  }
+  catch (Exception $e) {
+    watchdog('mailchimp', 'An error occurred triggering a workflow automation. Workflow: @automation, Email: @email. The automation did not successfully complete. "%message"', array(
+      '@automation' => $automation_entity->label,
+      '@email' => $email,
+      '%message' => $e->getMessage(),
+    ), WATCHDOG_ERROR);
+  }
+}
+
+/**
+ * Queries to see if there is an existing automation entity
+ *
+ * @param string $type
+ *   The entity type name
+ * @param string $bundle
+ *   The Drupal bundle for the entity
+ *
+ * @return Object
+ *   The mailchimp_automations_entity
+ */
+function mailchimp_automations_entity_automation($type, $bundle) {
+  $query = new EntityFieldQuery();
+
+  $query->entityCondition('entity_type', 'mailchimp_automations_entity')
+    ->propertyCondition('entity_type', $type)
+    ->propertyCondition('bundle', $bundle)
+    ->propertyCondition('status', 1);
+
+  $result = $query->execute();
+  if ($result) {
+    $entity_array = entity_load('mailchimp_automations_entity', array_keys($result['mailchimp_automations_entity']));
+    return reset($entity_array);
+  }
+  return NULL;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function mailchimp_automations_permission() {
+  $return = array();
+
+  $return['administer mailchimp automations'] = array(
+    'title' => t('Administer MailChimp automation entities'),
+    'description' => t('Add, Delete, and Configure MailChimp Automation entity settings.'),
+  );
+  return $return;
+}


### PR DESCRIPTION
Per our email conversation, here's the initial, working implementation of the mailchimp automations module added to the suite. I've tested this with an entityform on our site, and it works great! 

Feedback welcome!
