### PR TITLE
Multiple key support updated

### DIFF
--- a/mailchimp.api.php
+++ b/mailchimp.api.php
@@ -56,3 +56,15 @@ function hook_mailchimp_subscribe_user($list_id, $email, $merge_vars) {
 function hook_mailchimp_unsubscribe_user($list_id, $email) {
 
 }
+
+/**
+ * Alter the key for a given api request.
+ *
+ * @string &$api_key
+ *   The MailChimp API key.
+ * @array $context
+ *   The MailChimp API classname of the API object.
+ */
+function hook_mailchimp_api_key_alter(&$api_key, $context) {
+
+}

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -109,11 +109,13 @@ function mailchimp_apikey_ready_access($permission) {
  *
  * @param string $classname
  *   The MailChimp library class to instantiate.
+ * @param string $api_key
+ *   The MailChimp api key to use if not the default.
  *
  * @return Mailchimp
  *   Instance of the MailChimp library class. Can be overridden by $classname.
  */
-function mailchimp_get_api_object($classname = 'Mailchimp') {
+function mailchimp_get_api_object($classname = 'Mailchimp', $api_key = NULL) {
   // Set correct library class namespace depending on test mode.
   if (variable_get('mailchimp_test_mode', FALSE)) {
     $classname = '\Mailchimp\Tests\\' . $classname;
@@ -123,7 +125,7 @@ function mailchimp_get_api_object($classname = 'Mailchimp') {
   }
 
   $mailchimp = &drupal_static(__FUNCTION__);
-  if (isset($mailchimp) && $mailchimp instanceof $classname) {
+  if (!$api_key && isset($mailchimp) && $mailchimp instanceof $classname) {
     return $mailchimp;
   }
   if (module_exists('libraries')) {
@@ -146,7 +148,20 @@ function mailchimp_get_api_object($classname = 'Mailchimp') {
     return NULL;
   }
 
-  $api_key = variable_get('mailchimp_api_key', '');
+  $context = array(
+    'api_class' => $classname,
+  );
+  if (!$api_key) {
+    $api_key = $default_api_key = variable_get('mailchimp_api_key', '');
+    // Allow modules to alter the default.
+    drupal_alter('mailchimp_api_key', $api_key, $context);
+    // Check to see if the key was altered.
+    if ($api_key !== $default_api_key) {
+      // Invalidate all caches because the key was altered.
+      mailchimp_cache_clear_all();
+    }
+  }
+
   if (!strlen($api_key)) {
     watchdog('mailchimp', t('MailChimp Error: API Key cannot be blank.'), array(), WATCHDOG_ERROR);
     return NULL;
@@ -1230,6 +1245,13 @@ function mailchimp_cache_clear_list_activity($list_id) {
  */
 function mailchimp_cache_clear_campaign($campaign_id) {
   cache_clear_all('mailchimp_campaign_' . $campaign_id, 'cache_mailchimp');
+}
+
+/**
+ * Clear all mailchimp caches.
+ */
+function mailchimp_cache_clear_all() {
+  cache_clear_all('*', 'cache_mailchimp', TRUE);
 }
 
 /**

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -50,7 +50,7 @@ function mailchimp_menu() {
 
   $items['admin/config/services/mailchimp'] = array(
     'title' => 'MailChimp',
-    'description' => t('Manage MailChimp Settings.'),
+    'description' => 'Manage MailChimp Settings.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('mailchimp_admin_settings'),
     'access arguments' => array('administer mailchimp'),
@@ -58,7 +58,7 @@ function mailchimp_menu() {
     'type' => MENU_NORMAL_ITEM,
   );
   $items['admin/config/services/mailchimp/global'] = array(
-    'title' => t('Global Settings'),
+    'title' => 'Global Settings',
     'type' => MENU_DEFAULT_LOCAL_TASK,
     'weight' => -10,
   );
@@ -163,7 +163,7 @@ function mailchimp_get_api_object($classname = 'Mailchimp', $api_key = NULL) {
   }
 
   if (!strlen($api_key)) {
-    watchdog('mailchimp', t('MailChimp Error: API Key cannot be blank.'), array(), WATCHDOG_ERROR);
+    watchdog('mailchimp', 'MailChimp Error: API Key cannot be blank.', array(), WATCHDOG_ERROR);
     return NULL;
   }
   // Set the timeout to something that won't take down the Drupal site:
@@ -419,7 +419,7 @@ function mailchimp_get_memberinfo($list_id, $email, $reset = FALSE) {
  * @param string $list_id
  *   Unique string identifier for the list on your MailChimp account.
  * @param string $email
- *   Email address to check for on the identified MailChimp List
+ *   Email address to check for on the identified MailChimp List.
  * @param bool $reset
  *   Set to TRUE to ignore the cache. (Used heavily in testing functions.)
  *
@@ -478,7 +478,7 @@ function mailchimp_subscribe_process($list_id, $email, $merge_vars = NULL, $inte
     }
 
     $parameters = array(
-      // If double opt-in is required, set member status to 'pending'
+      // If double opt-in is required, set member status to 'pending'.
       'status' => ($double_optin) ? \Mailchimp\MailchimpLists::MEMBER_STATUS_PENDING : \Mailchimp\MailchimpLists::MEMBER_STATUS_SUBSCRIBED,
       'email_type' => $format,
     );
@@ -790,10 +790,6 @@ function mailchimp_batch_update_members($list_id, $batch, $double_in = FALSE) {
  * @param bool $notify
  *   Indicates whether to send the unsubscribe notification email to the address
  *   defined in the list email notification settings.
- * @param object $mcapi
- *   MailChimp API object if one is already loaded.
- * @param bool $allow_async
- *   Set to TRUE to allow asynchronous processing using DrupalQueue.
  *
  * @return bool
  *   Indicates whether unsubscribe was successful.
@@ -905,7 +901,7 @@ function mailchimp_get_segments($list_id, $reset = NULL) {
  * @param string $name
  *   A label for the segment.
  * @param string $type
- *   'static' or 'saved'
+ *   Can be 'static' or 'saved'.
  * @param array $segment_options
  *   Array of options for 'saved' segments. See MailChimp API docs.
  *
@@ -948,11 +944,11 @@ function mailchimp_segment_create($list_id, $name, $type, $segment_options = NUL
  * Add a specific subscriber to a static segment of a list.
  *
  * @param string $list_id
- *   ID of a MailChimp list
+ *   ID of a MailChimp list.
  * @param string $segment_id
- *   ID of a segment of the MailChimp list
+ *   ID of a segment of the MailChimp list.
  * @param string $email
- *   Email address to add to the segment (does NOT subscribe to the list)
+ *   Email address to add to the segment (does NOT subscribe to the list).
  * @param bool $batch
  *   Whether to queue this for the batch processor. Defaults to TRUE.
  * @param string $queue_id
@@ -993,11 +989,11 @@ function mailchimp_segment_add_subscriber($list_id, $segment_id, $email, $batch 
  * Add a batch of email addresses to a static segment of a list.
  *
  * @param string $list_id
- *   ID of a MailChimp list
+ *   ID of a MailChimp list.
  * @param string $segment_id
- *   ID of a segment of the MailChimp list
+ *   ID of a segment of the MailChimp list.
  * @param array $batch
- *   Batch of email addresses to add to the segment (does NOT subscribe new)
+ *   Batch of email addresses to add to the segment (does NOT subscribe new).
  *
  * @return int
  *   Successful subscribe count
@@ -1175,7 +1171,7 @@ function mailchimp_webhook_add($list_id, $url, $events = array(), $sources = arr
     return $result->id;
   }
   catch (Exception $e) {
-    watchdog('mailchimp', t('An error occurred adding webhook for list @list. "%message"'), array(
+    watchdog('mailchimp', 'An error occurred adding webhook for list @list. "%message"', array(
       '@list' => $list_id,
       '%message' => $e->getMessage(),
     ), WATCHDOG_ERROR);
@@ -1331,7 +1327,6 @@ function mailchimp_webhook_url() {
   return $GLOBALS['base_url'] . '/mailchimp/webhook/' . mailchimp_webhook_key();
 }
 
-
 /**
  * Helper function to generate form elements for a list's interest groups.
  *
@@ -1395,7 +1390,7 @@ function mailchimp_interest_groups_form_elements($list, $defaults = array(), $em
           $default_values[$group->id][] = $interest->id;
         }
       }
-      else if (!empty($defaults)) {
+      elseif (!empty($defaults)) {
         if (isset($defaults[$group->id][$interest->id]) && !empty($defaults[$group->id][$interest->id])) {
           $default_values[$group->id][] = $interest->id;
         }
@@ -1468,6 +1463,7 @@ function mailchimp_insert_drupal_form_tag($mergevar) {
         '#maxlength' => 2,
       );
       break;
+
     case 'dropdown':
       // Dropdown is mapped to <select> element in Drupal Form API.
       $input['#type'] = 'select';


### PR DESCRIPTION
This is an updated pr to support multiple api keys after further discussion of the [previous implementation](https://github.com/thinkshout/mailchimp/pull/223/).

Note that it includes a 2nd commit that merely fixes some legacy code sniffer warnings. These are unrelated to the current pull request. 
