### PR TITLE
Profile a return on error that supplies the error details.

### DIFF
--- a/mailchimp.module
+++ b/mailchimp.module
@@ -467,9 +467,10 @@ function mailchimp_subscribe($list_id, $email, $merge_vars = NULL, $interests = 
  *
  * @return object
  *   On success a result object will be returned from Mailchimp. On failure an
- *   object will be returned with the succcess as false, response code, and
- *   message. To check for a failure if the property 'success' of the object
- *   returned to be set to FALSE.
+ *   object will be returned with the property succcess set to FALSE, the 
+ *   response code as a property, and the message as a property. To check for 
+ *   a failure, look for the property 'success' of the object returned to 
+ *   be set to FALSE.
  */
 function mailchimp_subscribe_process($list_id, $email, $merge_vars = NULL, $interests = array(), $double_optin = FALSE, $format = 'html') {
   $result = FALSE;

--- a/mailchimp.module
+++ b/mailchimp.module
@@ -465,8 +465,11 @@ function mailchimp_subscribe($list_id, $email, $merge_vars = NULL, $interests = 
  *
  * @see Mailchimp_Lists::subscribe()
  *
- * @return bool
- *   True on success.
+ * @return object
+ *   On success a result object will be returned from Mailchimp. On failure an
+ *   object will be returned with the succcess as false, response code, and
+ *   message. To check for a failure if the property 'success' of the object
+ *   returned to be set to FALSE.
  */
 function mailchimp_subscribe_process($list_id, $email, $merge_vars = NULL, $interests = array(), $double_optin = FALSE, $format = 'html') {
   $result = FALSE;
@@ -523,14 +526,20 @@ function mailchimp_subscribe_process($list_id, $email, $merge_vars = NULL, $inte
     }
   }
   catch (Exception $e) {
-    watchdog('mailchimp', 'An error occurred subscribing @email to list @list. "%message"', array(
+    watchdog('mailchimp', 'An error occurred subscribing @email to list @list. Status code @code. "%message"', array(
       '@email' => $email,
       '@list' => $list_id,
       '%message' => $e->getMessage(),
+      '@code' => $e->getCode(),
     ), WATCHDOG_ERROR);
+    $result = new stdClass();
+    $result->success = FALSE;
+    $result->status = $e->getCode();
+    $result->message = $e->getMessage();
   }
-
-  return $result;
+  finally {
+    return $result;
+  }
 }
 
 /**


### PR DESCRIPTION
Other modules that may use the mailchimp_subscribe_process received no return if there was an error in processing the request. The Mailchimp API threw an exception that is squashed by mailchimp_subscribe_process and nothing is return on error except for logging to Watchdog. This commit provides a third-party module using mailchimp_subscribe_process a return if something goes wrong.
