### PR TITLE
Remove interest group ID from processing. It is not needed and not in…

### DIFF
--- a/mailchimp.module
+++ b/mailchimp.module
@@ -486,10 +486,8 @@ function mailchimp_subscribe_process($list_id, $email, $merge_vars = NULL, $inte
     // Set interests.
     if (!empty($interests)) {
       $selected_interests = array();
-      foreach ($interests as $interest_group) {
-        foreach ($interest_group as $interest_id => $interest_status) {
-          $selected_interests[$interest_id] = ($interest_status !== 0);
-        }
+      foreach ($interests as $interest_id => $interest_status) {
+        $selected_interests[$interest_id] = $interest_status;
       }
 
       if (!empty($selected_interests)) {


### PR DESCRIPTION
This PR stems from this discussion: https://www.drupal.org/node/2767865

This removes the Group ID within the Interest groups from mailchimp_subscribe_process(). The Group ID is discarded within mailchimp_subscribe_process(). The official API documentation does not require the Group ID, and there is no documentation in the Drupal Module that identifies that the module is opposite from the official API documentation. The simplest solution is to remove the Group ID and fall in line with the official MailChimp API documentation (http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/)
