### PR TITLE
Made MailChimp automation triggering more flexible

### DIFF
--- a/mailchimp.api.php
+++ b/mailchimp.api.php
@@ -82,6 +82,34 @@ function hook_mailchimp_automations_entity_options(&$entity_type_options, $autom
 }
 
 /**
+ * Perform an action when a related automation entity is created or updated.
+ *
+ * @param object $automation_entity
+ *   The MailchimpAutomationEntity object.
+ * @param string $action
+ *   'create' or 'update'.
+ * @param object $wrapped_entity
+ *   The EntityMetadataWrapper for the triggering entity.
+ */
+function hook_mailchimp_automations_entity_triggered($automation_entity, $action, $wrapper) {
+
+}
+
+/**
+ * Alter the email address before a workflow automation is triggered.
+ *
+ * @param string $email
+ *   The email address to which the automation will be sent.
+ * @param object $automation_entity
+ *   The MailchimpAutomationEntity object.
+ * @param object $wrapped_entity
+ *   The EntityMetadataWrapper for the triggering entity.
+ */
+function hook_mailchimp_automations_email_alter(&$email, $automation_entity, $wrapped_entity) {
+
+}
+
+/**
  * Alter mergevars before a workflow automation is triggered.
  *
  * @param array $merge_vars

--- a/modules/mailchimp_automations/mailchimp_automations.module
+++ b/modules/mailchimp_automations/mailchimp_automations.module
@@ -54,18 +54,31 @@ function mailchimp_automations_entity_access() {
 }
 
 /**
- * Implements hook_entity_insert().
+ * Implements hook_entity_presave().
  */
-function mailchimp_automations_entity_insert($entity, $type) {
+function mailchimp_automations_entity_presave($entity, $type) {
   $wrapper = entity_metadata_wrapper($type, $entity);
   $bundle = $wrapper->getBundle();
   if ($automation_entity = mailchimp_automations_entity_automation($type, $bundle)) {
+    $action = ($entity->is_new) ? 'create' : 'update';
+    module_invoke_all('mailchimp_automations_entity_triggered', $automation_entity, $action, $wrapper);
+  }
+}
+
+/**
+ * Implements hook_mailchimp_automations_entity_triggered().
+ */
+function mailchimp_automations_mailchimp_automations_entity_triggered($automation_entity, $action, $wrapper) {
+  if ($action == 'create') {
     $email_property_field = $automation_entity->email_property;
     $email = $wrapper->$email_property_field->value();
-    $merge_vars = NULL;
-    drupal_alter('mailchimp_automations_mergevars', $merge_vars, $automation_entity, $wrapper);
-    if ($result = mailchimp_automations_trigger_workflow($automation_entity->list_id, $automation_entity->workflow_id, $automation_entity->workflow_email_id, $email, $merge_vars)) {
-      module_invoke_all('mailchimp_automations_workflow_email_triggered', $automation_entity, $email, $wrapper);
+    drupal_alter('mailchimp_automations_email', $email, $automation_entity, $wrapper);
+    if (!empty($email)) {
+      $merge_vars = NULL;
+      drupal_alter('mailchimp_automations_mergevars', $merge_vars, $automation_entity, $wrapper);
+      if ($result = mailchimp_automations_trigger_workflow($automation_entity->list_id, $automation_entity->workflow_id, $automation_entity->workflow_email_id, $email, $merge_vars)) {
+        module_invoke_all('mailchimp_automations_workflow_email_triggered', $automation_entity, $email, $wrapper);
+      }
     }
   }
 }

--- a/modules/mailchimp_automations/mailchimp_automations.module
+++ b/modules/mailchimp_automations/mailchimp_automations.module
@@ -60,7 +60,13 @@ function mailchimp_automations_entity_insert($entity, $type) {
   $wrapper = entity_metadata_wrapper($type, $entity);
   $bundle = $wrapper->getBundle();
   if ($automation_entity = mailchimp_automations_entity_automation($type, $bundle)) {
-    mailchimp_automations_trigger_workflow($automation_entity, $wrapper);
+    $email_property_field = $automation_entity->email_property;
+    $email = $wrapper->$email_property_field->value();
+    $merge_vars = NULL;
+    drupal_alter('mailchimp_automations_mergevars', $merge_vars, $automation_entity, $wrapper);
+    if ($result = mailchimp_automations_trigger_workflow($automation_entity->list_id, $automation_entity->workflow_id, $automation_entity->workflow_email_id, $email, $merge_vars)) {
+      module_invoke_all('mailchimp_automations_workflow_email_triggered', $automation_entity, $email, $wrapper);
+    }
   }
 }
 
@@ -150,40 +156,43 @@ function mailchimp_automations_get_emails_for_workflow($workflow_id) {
 /**
  * Triggers a workflow automation via the MailChimp API.
  *
- * @param object $automation
- *   The MailchimpAutomationsEntity object from the database.
- * @param EntityMetadataWrapper $wrapped_entity
- *   The wrapped entity that triggered the workflow automation.
+ * @param string $list_id
+ *   The MailChimp list ID.
+ * @param string $workflow_id
+ *   The MailChimp workflow ID.
+ * @param string $workflow_email_id
+ *   The MailChimp workflow email ID.
+ * @param string $email
+ *   The email to which the workflow is being sent.
+ * @param array $merge_vars
+ *   Optional merge_vars that will be passed to MailChimp.
  */
-function mailchimp_automations_trigger_workflow($automation_entity, $wrapped_entity) {
-  $email_property_field = $automation_entity->email_property;
-  $email = $wrapped_entity->$email_property_field->value();
-  if (!mailchimp_is_subscribed($automation_entity->list_id, $email)) {
-    $merge_vars = NULL;
-    drupal_alter('mailchimp_automations_mergevars', $merge_vars, $automation_entity, $wrapped_entity);
+function mailchimp_automations_trigger_workflow($list_id, $workflow_id, $workflow_email_id, $email, $merge_vars=NULL) {
+  if (!mailchimp_is_subscribed($list_id, $email)) {
     // Skip mailchimp_subscribe to avoid cron if set
-    $added = mailchimp_subscribe_process($automation_entity->list_id, $email, $merge_vars);
+    $added = mailchimp_subscribe_process($list_id, $email, $merge_vars);
     if (!$added) {
-      watchdog('mailchimp', 'An error occurred subscribing @email to list @list during a workflow @automation. The automation did not comlplete.', array(
-        '@automation' => $automation_entity->label,
+      watchdog('mailchimp', 'An error occurred subscribing @email to list @list_id during workflow automation @workflow_email_id. The automation did not comlplete.', array(
         '@email' => $email,
+        '@list_id' => $list_id,
+        '@workflow_email_id' => $workflow_email_id,
       ), WATCHDOG_ERROR);
+      $result = FALSE;
     }
   }
   $mc_auto = mailchimp_get_api_object('MailchimpAutomations');
   try {
-    $result = $mc_auto->addWorkflowEmailSubscriber($automation_entity->workflow_id, $automation_entity->workflow_email_id, $email);
-    if ($result) {
-      module_invoke_all('mailchimp_automations_workflow_email_triggered', $automation_entity, $email, $wrapped_entity);
-    }
+    $result = $mc_auto->addWorkflowEmailSubscriber($workflow_id, $workflow_email_id, $email);
   }
   catch (Exception $e) {
-    watchdog('mailchimp', 'An error occurred triggering a workflow automation. Workflow: @automation, Email: @email. The automation did not successfully complete. "%message"', array(
-      '@automation' => $automation_entity->label,
+    watchdog('mailchimp', 'An error occurred triggering a workflow automation for workflow automation @workflow_email_id, Email: @email. The automation did not successfully complete. "%message"', array(
+      '@workflow_email_id' => $workflow_email_id,
       '@email' => $email,
       '%message' => $e->getMessage(),
     ), WATCHDOG_ERROR);
+    $result = FALSE;
   }
+  return $result;
 }
 
 /**


### PR DESCRIPTION
Hi guys. I'm working on a blog entry about MailChimp automations, and realized that many of my theoretical examples require the automation trigger method parameters to map more closely to the API call itself. This will enable, for example, a user to trigger an automation directly when an entity is created that does not have an email address but is associated to a user who does (eg. a user buys a product). 

Please let me know if you have questions or concerns. Thanks!